### PR TITLE
Feature/add option to disable word popover

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ScripturePane/README.md
+++ b/src/components/ScripturePane/README.md
@@ -5,29 +5,59 @@ import { ScripturePane, useScripture } from "../.."
 
 // for testing NT book
 
-// const reference = {
-//   projectId: "tit",
-//   chapter: 1,
-//   verse: 1,
-// };
-// const resource = {
-//   owner: "unfoldingWord",
-//   languageId: "en",
-//   projectId: "ust",
-// };
-// const direction = 'ltr';
+const EnglishExample = {
+  reference: {
+    projectId: "tit",
+    chapter: 1,
+    verse: 5,
+  },
+  resource: {
+    owner: "unfoldingWord",
+    languageId: "en",
+    projectId: "ust",
+  },
+  direction: 'ltr',
+  disableWordPopover: true,
+}
 
-const reference = {
-  projectId: "psa",
-  chapter: 119,
-  verse: 166,
-};
-const resource = {
-  owner: "unfoldingWord",
-  languageId: "hbo",
-  projectId: "uhb",
-};
-const direction = 'rtl';
+const HebrewExample = {
+  reference: {
+    projectId: "psa",
+    chapter: 119,
+    verse: 166,
+  },
+  resource: {
+    owner: "unfoldingWord",
+    languageId: "hbo",
+    projectId: "uhb",
+  },
+  direction: 'rtl',
+  disableWordPopover: false,
+}
+
+const GreekExample = {
+  reference: {
+    projectId: "tit",
+    chapter: 1,
+    verse: 5,
+  },
+  resource: {
+    owner: "unfoldingWord",
+    languageId: "el-x-koine",
+    projectId: "ugnt",
+  },
+  direction: 'ltr',
+  disableWordPopover: false,
+}
+
+///////////////////////////////////////////
+// enable one of the following bible config lines to see various examples
+
+const scripture = HebrewExample;
+// const scripture = GreekExample;
+// const scripture = EnglishExample;
+
+///////////////////////////////////////////
 
 const config = {
   server: "https://git.door43.org",
@@ -54,7 +84,7 @@ function Component() {
   })
 
   const scriptureConfig = useScripture({
-    reference, resource, config,
+    ...scripture, config
   });
 
   const refStyle = {
@@ -82,7 +112,7 @@ function Component() {
       setMarkdownView={setMarkdownView}
       title="Scripture"
     >
-      <ScripturePane refStyle={refStyle} contentStyle={contentStyle} {...scriptureConfig} direction={direction} />
+      <ScripturePane refStyle={refStyle} contentStyle={contentStyle} {...scriptureConfig} direction={scripture.direction} />
     </Card>
   );
 }

--- a/src/hooks/index.tsx
+++ b/src/hooks/index.tsx
@@ -6,14 +6,21 @@ import {
 } from '../types';
 
 interface Props {
+  /** reference for scripture **/
   reference: ScriptureReference;
+  /** where to get data **/
   config: ServerConfig;
+  /** optional direct path to bible resource, in format ${owner}/${languageId}/${projectId}/${branch} **/
   resourceLink: string|undefined;
+  /** optional resource object to use to build resourceLink **/
   resource: ScriptureResource|undefined;
+  /** if true then do not display lexicon popover on hover **/
+  disableWordPopover: boolean|undefined;
 }
 
 export function useScripture({
-  reference, resourceLink: resourceLink_, config, resource: resource_,
+  reference, resourceLink: resourceLink_, config,
+  resource: resource_, disableWordPopover,
 }: Props) {
   let resourceLink = resourceLink_;
 
@@ -34,7 +41,7 @@ export function useScripture({
   const { verseObjects } = bibleJson || {};
 
   if (verseObjects) {
-    content = <VerseObjects verseObjects={verseObjects} />;
+    content = <VerseObjects verseObjects={verseObjects} disableWordPopover={disableWordPopover} />;
   }
 
   return {


### PR DESCRIPTION
- test with https://deploy-preview-47--create-app.netlify.app/ , should only see lexicon popups when you hover over Greek or Hebrew scriptures.  Therefore, you should not see popovers when you hover over English scriptures, etc.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/single-scripture-rcl/9)
<!-- Reviewable:end -->
