### PR TITLE
Feature/scripture label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "0.1.9",
+  "version": "0.1.10-alpha",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "0.1.10",
+  "version": "0.1.10-alpha.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "0.1.10-alpha.2",
+  "version": "0.1.10",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -5,13 +5,13 @@ import { ScripturePane, ScriptureSelector } from '..'
 import { updateTitle } from '../../utils/ScriptureVersionHistory'
 import { useScriptureSettings } from '../../hooks/useScriptureSettings'
 import { getScriptureVersionSettings } from '../../utils/ScriptureSettings'
+import { Title } from '../ScripturePane/styled'
 
 const label = 'Version'
 const style = { marginTop: '16px', width: '500px' }
 
 export default function ScriptureCard(Props) {
   const {
-    title,
     classes,
     getLanguage,
   } = Props
@@ -50,6 +50,12 @@ export default function ScriptureCard(Props) {
     },
   } = useCardState({ items })
 
+  const labelStyle = {
+    fontFamily: 'Noto Sans',
+    fontSize: `16px`,
+    maxWidth: '100%',
+  }
+
   const refStyle = {
     fontFamily: 'Noto Sans',
     fontSize: `${Math.round(fontSize * 0.9)}%`,
@@ -60,9 +66,12 @@ export default function ScriptureCard(Props) {
     fontSize: `${fontSize}%`,
   }
 
+  const scriptureLabel =
+    <Title style={labelStyle}>{scriptureConfig.title} v{scriptureConfig.version}</Title>
+
   return (
     <Card
-      title={title}
+      title={scriptureLabel}
       items={items}
       classes={classes}
       headers={headers}

--- a/src/components/ScripturePane/ScripturePane.tsx
+++ b/src/components/ScripturePane/ScripturePane.tsx
@@ -46,7 +46,6 @@ function ScripturePane(
 
   return (
     <Container dir={direction}>
-      <Title style={{ marginBottom: 12 }}>{title} v{version}</Title>
       <Content>
         <span style={refStyle}> {chapter}:{verse}&nbsp;</span>
         <span style={contentStyle}>{content}</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9224,10 +9224,10 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-scripture-resources-rcl@3.2.0-alpha:
-  version "3.2.0-alpha"
-  resolved "https://registry.yarnpkg.com/scripture-resources-rcl/-/scripture-resources-rcl-3.2.0-alpha.tgz#167b3c3e960bb10007b9087e5cf591a51724ff6f"
-  integrity sha512-VYul+TKrviXWj3BAHlvt+A5Va+hEKQMLGzE77QQtP8GhS5mX6toVCWTBESaLhQZkFTwZcmEz42xIBvywjWNlhg==
+scripture-resources-rcl@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/scripture-resources-rcl/-/scripture-resources-rcl-3.0.4.tgz#c2497d61a3f461267759bb892e25dde275b9c0ff"
+  integrity sha512-cYPcWHI7mCvoiIEBJYE1dUBO2DOqaO3S3gggxEY4f0A4DrM7CikSvfIt7DUV9qxGE3QFNS4jpTZy3mY2rHNX4A==
   dependencies:
     deep-freeze "^0.0.1"
     gitea-react-toolkit "1.3.13"


### PR DESCRIPTION
## Describe what your pull request addresses
- moved scripture version title to the card title for more efficient space utilization.


## Testing:
- can test with https://deploy-preview-56--create-app.netlify.app/
- scripture pane titles should look like:

![Screen Shot 2021-02-10 at 1 29 48 PM](https://user-images.githubusercontent.com/14238574/108102235-48741e80-7056-11eb-85f5-e2cb39773e80.png)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/single-scripture-rcl/15)
<!-- Reviewable:end -->
