### PR TITLE
Feature/help for scripture selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "1.2.0",
+  "version": "1.3.0-alpha",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "1.3.0-alpha.2",
+  "version": "1.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "1.3.0-alpha",
+  "version": "1.3.0-alpha.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ComboBox/ComboBox.tsx
+++ b/src/components/ComboBox/ComboBox.tsx
@@ -9,10 +9,20 @@ import * as PropTypes from 'prop-types'
 import { useComboBox } from '../../hooks'
 
 export function ComboBox({
-  label, options, current, allowUserInput, onChange, style,
+  label,
+  options,
+  current,
+  allowUserInput,
+  onChange,
+  style,
 }) {
   const { state, actions } = useComboBox({
-    label, options, current, allowUserInput, onChange,
+    label,
+    options,
+    current,
+    allowUserInput,
+    onChange,
+    initialPrompt: null,
   })
 
   return (

--- a/src/components/ScriptureSelector/ScriptureSelector.tsx
+++ b/src/components/ScriptureSelector/ScriptureSelector.tsx
@@ -15,7 +15,7 @@ export function ScriptureSelector({
   const initialPrompt = 'Choose version or enter Door43 URL'
 
   const { state, actions } = useScriptureSelector({
-    label,
+    label: initialPrompt,
     options,
     current,
     allowUserInput,

--- a/src/components/ScriptureSelector/ScriptureSelector.tsx
+++ b/src/components/ScriptureSelector/ScriptureSelector.tsx
@@ -16,6 +16,8 @@ export function ScriptureSelector({
     label, options, current, allowUserInput, onChange, deleteItem,
   })
 
+  const userPrompt = 'Choose version or enter Door43 URL'
+
   return (
     <Autocomplete
       selectOnFocus
@@ -30,7 +32,7 @@ export function ScriptureSelector({
           error={!!errorMessage}
           helperText={errorMessage}
           {...params}
-          label={label}
+          label={userPrompt}
           variant="outlined"
         />
       )}

--- a/src/components/ScriptureSelector/ScriptureSelector.tsx
+++ b/src/components/ScriptureSelector/ScriptureSelector.tsx
@@ -12,11 +12,17 @@ import { useScriptureSelector } from '../../hooks'
 export function ScriptureSelector({
   label, options, current, allowUserInput, onChange, style, deleteItem, errorMessage,
 }) {
-  const { state, actions } = useScriptureSelector({
-    label, options, current, allowUserInput, onChange, deleteItem,
-  })
+  const initialPrompt = 'Choose version or enter Door43 URL'
 
-  const userPrompt = 'Choose version or enter Door43 URL'
+  const { state, actions } = useScriptureSelector({
+    label,
+    options,
+    current,
+    allowUserInput,
+    onChange,
+    deleteItem,
+    initialPrompt,
+  })
 
   return (
     <Autocomplete
@@ -32,7 +38,7 @@ export function ScriptureSelector({
           error={!!errorMessage}
           helperText={errorMessage}
           {...params}
-          label={userPrompt}
+          label={initialPrompt}
           variant="outlined"
         />
       )}

--- a/src/hooks/useComboBox.tsx
+++ b/src/hooks/useComboBox.tsx
@@ -7,6 +7,15 @@ import { createFilterOptions } from '@material-ui/lab/Autocomplete'
 
 const filter = createFilterOptions()
 
+/**
+ * business logic for combobox
+ * @param label - text to display in input box
+ * @param options - array of options to show in dropdown
+ * @param current - array index into options of current selection
+ * @param allowUserInput - if true then user can type in any text
+ * @param onChange - callback function for when user makes a selection
+ * @param initialPrompt - if true selects displaying label initially in input box, otherwise it will show current selection
+ */
 export function useComboBox({
   label,
   options,

--- a/src/hooks/useComboBox.tsx
+++ b/src/hooks/useComboBox.tsx
@@ -7,15 +7,21 @@ import { createFilterOptions } from '@material-ui/lab/Autocomplete'
 
 const filter = createFilterOptions()
 
-/**
- * business logic for combobox
- * @param label - text to display in input box
- * @param options - array of options to show in dropdown
- * @param current - array index into options of current selection
- * @param allowUserInput - if true then user can type in any text
- * @param onChange - callback function for when user makes a selection
- * @param initialPrompt - if true selects displaying label initially in input box, otherwise it will show current selection
- */
+interface Props {
+  /** text to display in input box */
+  label: string,
+  /** array of options to show in dropdown */
+  options: any[],
+  /** array index into options of current selection */
+  current: number,
+  /** if true then user can type in any text */
+  allowUserInput: boolean,
+  /** callback function for when user makes a selection */
+  onChange: Function,
+  /** if truthy the label is initially shown in input box, otherwise current selection shown */
+  initialPrompt: any | null,
+}
+
 export function useComboBox({
   label,
   options,
@@ -23,7 +29,7 @@ export function useComboBox({
   allowUserInput,
   onChange,
   initialPrompt,
-}) {
+}: Props) {
   const currentOption = ((current >= 0) && (current < options.length)) ? options[current] : ''
   const [value, setValue] = React.useState(initialPrompt ? null : currentOption)
 

--- a/src/hooks/useComboBox.tsx
+++ b/src/hooks/useComboBox.tsx
@@ -8,10 +8,15 @@ import { createFilterOptions } from '@material-ui/lab/Autocomplete'
 const filter = createFilterOptions()
 
 export function useComboBox({
-  label, options, current, allowUserInput, onChange,
+  label,
+  options,
+  current,
+  allowUserInput,
+  onChange,
+  initialPrompt,
 }) {
   const currentOption = ((current >= 0) && (current < options.length)) ? options[current] : ''
-  const [value, setValue] = React.useState(currentOption)
+  const [value, setValue] = React.useState(initialPrompt ? null : currentOption)
 
   const handleChange = (event, newValue) => {
     let newSelection = newValue

--- a/src/hooks/useScriptureSelector.tsx
+++ b/src/hooks/useScriptureSelector.tsx
@@ -9,10 +9,21 @@ import { delay } from '../utils/delay'
 import { useComboBox } from './useComboBox'
 
 export function useScriptureSelector({
-  label, options, current, allowUserInput, onChange, deleteItem,
+  label,
+  options,
+  current,
+  allowUserInput,
+  onChange,
+  deleteItem,
+  initialPrompt,
 }) {
   let { state, actions } = useComboBox({
-    label, options, current, allowUserInput, onChange,
+    label,
+    options,
+    current,
+    allowUserInput,
+    onChange,
+    initialPrompt,
   })
   const [currentOptions, setOptions] = React.useState(state.options)
 

--- a/src/hooks/useScriptureSelector.tsx
+++ b/src/hooks/useScriptureSelector.tsx
@@ -8,6 +8,16 @@ import Tooltip from '@material-ui/core/Tooltip'
 import { delay } from '../utils/delay'
 import { useComboBox } from './useComboBox'
 
+/**
+ * business logic for combobox
+ * @param label - text to display in input box
+ * @param options - array of options to show in dropdown
+ * @param current - array index into options of current selection
+ * @param allowUserInput - if true then user can type in any text
+ * @param onChange - callback function for when user makes a selection
+ * @param deleteItem - callback function for when user delectes a scripture
+ * @param initialPrompt - if true selects displaying label initially in input box, otherwise it will show current selection
+ */
 export function useScriptureSelector({
   label,
   options,

--- a/src/hooks/useScriptureSelector.tsx
+++ b/src/hooks/useScriptureSelector.tsx
@@ -8,16 +8,23 @@ import Tooltip from '@material-ui/core/Tooltip'
 import { delay } from '../utils/delay'
 import { useComboBox } from './useComboBox'
 
-/**
- * business logic for combobox
- * @param label - text to display in input box
- * @param options - array of options to show in dropdown
- * @param current - array index into options of current selection
- * @param allowUserInput - if true then user can type in any text
- * @param onChange - callback function for when user makes a selection
- * @param deleteItem - callback function for when user delectes a scripture
- * @param initialPrompt - if true selects displaying label initially in input box, otherwise it will show current selection
- */
+interface Props {
+  /** text to display in input box */
+  label: string,
+  /** array of options to show in dropdown */
+  options: any[],
+  /** array index into options of current selection */
+  current: number,
+  /** if true then user can type in any text */
+  allowUserInput: boolean,
+  /** callback function for when user makes a selection */
+  onChange: Function,
+  /** callback function for when user makes deletes a scripture from options */
+  deleteItem: Function,
+  /** if truthy the label is initially shown in input box, otherwise current selection shown */
+  initialPrompt: any | null,
+}
+
 export function useScriptureSelector({
   label,
   options,
@@ -26,7 +33,7 @@ export function useScriptureSelector({
   onChange,
   deleteItem,
   initialPrompt,
-}) {
+}: Props) {
   let { state, actions } = useComboBox({
     label,
     options,


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] add help instructions for scripture selection

## Test Instructions
- can test with: https://deploy-preview-145--gateway-edit.netlify.app/
- [ ] when you open scripture pane settings, you should see this until you make a selection:

<img width="550" alt="Screen Shot 2021-04-04 at 9 29 48 PM" src="https://user-images.githubusercontent.com/14238574/113528003-51309d80-958d-11eb-9dd2-2f6cb193c737.png">

- [ ] when you click on the input box, it should transition to this until item selected or text is entered:

<img width="531" alt="Screen Shot 2021-04-04 at 9 32 32 PM" src="https://user-images.githubusercontent.com/14238574/113528117-a1a7fb00-958d-11eb-9fb0-b77774911f14.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/single-scripture-rcl/22)
<!-- Reviewable:end -->
