### PR TITLE
Bugfix/Fix scripture popups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "1.4.0-alpha",
+  "version": "1.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "1.3.0",
+  "version": "1.4.0-alpha",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ScriptureCard/README.md
+++ b/src/components/ScriptureCard/README.md
@@ -172,7 +172,6 @@ function Component() {
           classes={classes}
           server={config.server}
           branch={config.branch}
-          disableWordPopover={true}
           useLocalStorage={useLocalStorage}
           {...englishScripture}
         />
@@ -182,7 +181,6 @@ function Component() {
           classes={classes}
           server={config.server}
           branch={config.branch}
-          disableWordPopover={true}
           useLocalStorage={useLocalStorage}
           {...englishUstScripture}
         />

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -4,7 +4,7 @@ import { Card, useCardState } from 'translation-helps-rcl'
 import { ScripturePane, ScriptureSelector } from '..'
 import { updateTitle } from '../../utils/ScriptureVersionHistory'
 import { useScriptureSettings } from '../../hooks/useScriptureSettings'
-import { getScriptureVersionSettings } from '../../utils/ScriptureSettings'
+import { getScriptureVersionSettings, isOriginalBible } from '../../utils/ScriptureSettings'
 import { Title } from '../ScripturePane/styled'
 
 const KEY_FONT_SIZE_BASE = 'scripturePaneFontSize_'
@@ -115,6 +115,11 @@ export default function ScriptureCard({
   }
 
   const scriptureLabel = <Title>{scriptureTitle}</Title>
+  let disableWordPopover_ = disableWordPopover
+
+  if (disableWordPopover === undefined) { // if not specified, then determine if original language resource
+    disableWordPopover_ = !isOriginalBible(scriptureConfig['resource']?.projectId)
+  }
 
   return (
     <Card
@@ -145,7 +150,7 @@ export default function ScriptureCard({
         direction={direction}
         contentStyle={contentStyle}
         fontSize={fontSize}
-        disableWordPopover={disableWordPopover}
+        disableWordPopover={disableWordPopover_}
       />
     </Card>
   )

--- a/src/utils/ScriptureSettings.ts
+++ b/src/utils/ScriptureSettings.ts
@@ -59,6 +59,15 @@ export function getScriptureObject({
   return scripture
 }
 
+/**
+ * return true if resource is an original language bible
+ * @param resourceId
+ */
+export function isOriginalBible(resourceId) {
+  const isOrig = ((resourceId === NT_ORIG_LANG_BIBLE) || (resourceId === OT_ORIG_LANG_BIBLE) || (resourceId === ORIGINAL_SOURCE))
+  return isOrig
+}
+
 export function getScriptureResourceSettings(bookId, scriptureSettings_, isNewTestament) {
   const scriptureSettings = { ...scriptureSettings_ }
   scriptureSettings.disableWordPopover = DISABLE_WORD_POPOVER


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] make disableWordPopover dynamic if not specified

## Test Instructions
can test with: https://deploy-preview-148--gateway-edit.netlify.app/
- [ ] scripture panes should only show popups if not original language bible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/single-scripture-rcl/23)
<!-- Reviewable:end -->
