### PR TITLE
Bugfix/save settings by user

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.0.1-alpha",
+  "version": "2.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.0.0",
+  "version": "2.0.1-alpha",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -31,7 +31,6 @@ export default function ScriptureCard({
   },
   resourceLink,
   useUserLocalStorage,
-  userLocalStorage,
   disableWordPopover,
 }) {
   const [urlError, setUrlError] = React.useState(null)
@@ -54,7 +53,6 @@ export default function ScriptureCard({
     resourceId,
     resourceLink,
     useUserLocalStorage,
-    userLocalStorage,
     disableWordPopover,
     originalLanguageOwner,
     setUrlError,
@@ -202,6 +200,4 @@ ScriptureCard.propTypes = {
   resourceLink: PropTypes.any,
   /** use method for using local storage specific for user */
   useUserLocalStorage: PropTypes.func.isRequired,
-  /** object for stateless access of local storage for user */
-  userLocalStorage: PropTypes.object.isRequired,
 }

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -1,7 +1,7 @@
-import { useMemo } from 'react'
+import { useEffect } from 'react'
 import { core } from 'scripture-resources-rcl'
 import * as isEqual from 'deep-equal'
-import { ScriptureVersionHistory } from '../utils/ScriptureVersionHistory'
+import { KEY_SCRIPTURE_VER_HISTORY, ScriptureVersionHistory } from '../utils/ScriptureVersionHistory'
 import {
   INVALID_REPO_URL_ERROR,
   INVALID_URL,
@@ -75,7 +75,6 @@ export function useScriptureSettings({
   resourceId,
   resourceLink,
   useUserLocalStorage,
-  userLocalStorage,
   disableWordPopover,
   originalLanguageOwner,
   setUrlError,
@@ -92,13 +91,9 @@ export function useScriptureSettings({
     disableWordPopover,
     originalLanguageOwner,
   })
+  const [versionHistory, saveVersionHist, refreshVersionHist] = useUserLocalStorage(KEY_SCRIPTURE_VER_HISTORY, [], false)
+  const scriptureVersionHist = new ScriptureVersionHistory(versionHistory, saveVersionHist, refreshVersionHist)
 
-  const scriptureVersionHist = useMemo(
-    () => (new ScriptureVersionHistory(userLocalStorage)),
-    [userLocalStorage.userName],
-  )
-
-  scriptureVersionHist.addItemToHistory(scriptureDefaultSettings) // make sure default setting persisted in history
   let [scriptureSettings, setScriptureSettings] = useUserLocalStorage(KEY_SETTINGS_BASE + cardNum, scriptureDefaultSettings)
   const currentTarget = {
     server,
@@ -106,18 +101,24 @@ export function useScriptureSettings({
     languageId,
   }
   const [target, setTarget] = useUserLocalStorage(KEY_TARGET_BASE + cardNum, currentTarget)
-  fixScriptureSettings(scriptureVersionHist, scriptureSettings, languageId, cardNum, owner)
 
-  if (!isEqual(currentTarget, target)) { // when target changes, switch back to defaults
-    const oldDefaultSettings = { ...scriptureDefaultSettings, ...target }
-    oldDefaultSettings.resourceLink = getResourceLink(oldDefaultSettings)
-    scriptureVersionHist.removeItem(oldDefaultSettings) // remove old default settings from history
+  useEffect(() => {
+    if (languageId && owner) { // make sure we have languageId and owner selected first
+      fixScriptureSettings(scriptureVersionHist, scriptureSettings, languageId, cardNum, owner)
 
-    setScriptureSettings(scriptureDefaultSettings)
-    setTarget(currentTarget)
-  } else {
-    scriptureVersionHist.addItemToHistory(scriptureSettings) // make sure current setting persisted in history
-  }
+      if (!isEqual(currentTarget, target)) { // when target changes, switch back to defaults
+        const oldDefaultSettings = { ...scriptureDefaultSettings, ...target }
+        oldDefaultSettings.resourceLink = getResourceLink(oldDefaultSettings)
+        scriptureVersionHist.removeItem(oldDefaultSettings) // remove old default settings from history
+
+        setScriptureSettings(scriptureDefaultSettings)
+        setTarget(currentTarget)
+      } else {
+        scriptureVersionHist.addItemToHistory(scriptureSettings) // make sure current scripture version persisted in history
+      }
+    }
+  }, [languageId, owner, cardNum, scriptureDefaultSettings, scriptureVersionHist, scriptureSettings,
+    currentTarget, target, setScriptureSettings, setTarget])
 
   const scriptureConfig = useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament)
 

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -91,7 +91,7 @@ export function useScriptureSettings({
     disableWordPopover,
     originalLanguageOwner,
   })
-  const [versionHistory, saveVersionHist, refreshVersionHist] = useUserLocalStorage(KEY_SCRIPTURE_VER_HISTORY, [], false)
+  const [versionHistory, saveVersionHist, refreshVersionHist] = useUserLocalStorage(KEY_SCRIPTURE_VER_HISTORY, [])
   const scriptureVersionHist = new ScriptureVersionHistory(versionHistory, saveVersionHist, refreshVersionHist)
 
   let [scriptureSettings, setScriptureSettings] = useUserLocalStorage(KEY_SETTINGS_BASE + cardNum, scriptureDefaultSettings)

--- a/src/utils/ScriptureVersionHistory.ts
+++ b/src/utils/ScriptureVersionHistory.ts
@@ -1,15 +1,19 @@
 const maxItems = 7
-export const KEY = 'scriptureVersionHistory'
+export const KEY_SCRIPTURE_VER_HISTORY = 'scriptureVersionHistory'
 
 export class ScriptureVersionHistory {
-  userLocalStorage: any;
+  saveVersionHist: Function
+  readVersionHist: Function
+  versionHistory: Function
 
-  constructor(userLocalStorage) {
-    this.userLocalStorage = userLocalStorage
+  constructor(versionHistory, saveVersionHist, readVersionHist) {
+    this.versionHistory = versionHistory
+    this.saveVersionHist = saveVersionHist
+    this.readVersionHist = readVersionHist
   }
 
   saveHistory(history) {
-    this.userLocalStorage.save(KEY, history) // persist settings
+    this.saveVersionHist(history) // persist settings
   }
 
   updateTitle(resourceLink, title) { // update title for resourceLink
@@ -20,13 +24,13 @@ export class ScriptureVersionHistory {
     if (entry) {
       if (entry.title !== title) {
         history[index]['title'] = title // update the title
-        this.userLocalStorage.save(KEY, history) // persist settings
+        this.saveVersionHist(history) // persist settings
       }
     }
   }
 
   getLatest():any[] {
-    const value = this.userLocalStorage.read(KEY)
+    const value = this.readVersionHist()
     return value || []
   }
 
@@ -51,7 +55,7 @@ export class ScriptureVersionHistory {
 
     if ((index >= 0) && (index < history.length)) {
       history.splice(index, 1) // remove old item - we will add it back again to the front
-      this.userLocalStorage.save(KEY, history)
+      this.saveVersionHist(history)
     }
   }
 
@@ -99,7 +103,7 @@ export class ScriptureVersionHistory {
     }
 
     if (changed) {
-      this.userLocalStorage.save(KEY, history)
+      this.saveVersionHist(history)
     }
     return newIndex
   }


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ]  removed userLocalStorage as prop
- [ ] changed ScriptureVersionHistory to utilize useUserLocalStorage
- [ ] added checks to make sure we have values for languageId and owner before saving scripture settings

## Test Instructions
- can test with https://deploy-preview-156--gateway-edit.netlify.app/
- you will need two user accounts for testing
- [ ] open app
- [ ] if already logged in, do app logout
- [ ] in developer tools, clear local storage for app
- [ ] do page refresh
- [ ] do log in with first user account
- [ ] select organization and language
- [ ] app should open with default setup
- make misc changes:
  - [ ] change font size for a few cards
  - [ ] rearrange and resize some cards
  - [ ] change reference to something completely different like rut 3:2
  - [ ] in one of the scripture panes, set scripture to https://git.door43.org/ru_gl/ru_rsob
- [ ] do logout
- [ ] log back in with second user account - should see layout and settings go back to default
- [ ] open settings in one of the scripture panes.  Click on choose version and make sure Russian is not in list
- [ ] do logout again
- [ ] log back in with first user account and should see all your previous customizations restored

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/single-scripture-rcl/26)
<!-- Reviewable:end -->
