### PR TITLE
Bugfix/Fixes for long timeouts due to internet disconnects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.0.4-alpha.7",
+  "version": "2.0.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"
@@ -63,7 +63,7 @@
     "react-styleguidist": "^11.1.5",
     "scripture-resources-rcl": "4.1.8",
     "style-loader": "^2.0.0",
-    "translation-helps-rcl": "1.46.19",
+    "translation-helps-rcl": "1.47.0",
     "webpack": "^4.44.2"
   },
   "dependencies": {

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -43,6 +43,7 @@ export default function ScriptureCard({
   useUserLocalStorage,
   disableWordPopover,
   onResourceError,
+  timeout,
 }) {
   const [urlError, setUrlError] = React.useState(null)
   const [fontSize, setFontSize] = useUserLocalStorage(KEY_FONT_SIZE_BASE + cardNum, 100)
@@ -67,6 +68,7 @@ export default function ScriptureCard({
     disableWordPopover,
     originalLanguageOwner,
     setUrlError,
+    timeout,
   })
 
   let scriptureTitle
@@ -228,4 +230,6 @@ ScriptureCard.propTypes = {
    *      - isAccessError - is true if this was an error trying to access file
    *      - resourceStatus - is object containing details about problems fetching resource */
   onResourceError: PropTypes.func,
+  /** optional http timeout in milliseconds for fetching resources, default is 0 (very long wait) */
+  timeout: PropTypes.number,
 }

--- a/src/hooks/useScriptureResources.tsx
+++ b/src/hooks/useScriptureResources.tsx
@@ -10,7 +10,7 @@ import { getScriptureResourceSettings } from '../utils/ScriptureSettings'
  * @param {boolean} isNewTestament
  * @param {string} currentLanguageId - optional over-ride for transient case where language in scripture settings have not yet updated
  * @param {string} currentOwner - optional over-ride for transient case where owner in scripture settings have not yet updated
- * @param {number} timeout - optional http timeout in milliseconds for fetching resources, default is 0 (very long wait)
+ * @param {number} timeout - optional http timeout in milliseconds for fetching resources, default is 10 sec
  */
 export function useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament,
                                       currentLanguageId=null, currentOwner=null, timeout=10000) {

--- a/src/hooks/useScriptureResources.tsx
+++ b/src/hooks/useScriptureResources.tsx
@@ -10,8 +10,10 @@ import { getScriptureResourceSettings } from '../utils/ScriptureSettings'
  * @param {boolean} isNewTestament
  * @param {string} currentLanguageId - optional over-ride for transient case where language in scripture settings have not yet updated
  * @param {string} currentOwner - optional over-ride for transient case where owner in scripture settings have not yet updated
+ * @param {number} timeout - optional http timeout in milliseconds for fetching resources, default is 0 (very long wait)
  */
-export function useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament, currentLanguageId=null, currentOwner=null) {
+export function useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament,
+                                      currentLanguageId=null, currentOwner=null, timeout=10000) {
   const scriptureSettings_ = getScriptureResourceSettings(bookId, scriptureSettings, isNewTestament, currentLanguageId, currentOwner) // convert any default settings strings
 
   const scriptureConfig_ = {
@@ -30,6 +32,7 @@ export function useScriptureResources(bookId, scriptureSettings, chapter, verse,
     config: {
       server: scriptureSettings_.server,
       cache: { maxAge: 60 * 1000 },
+      timeout,
     },
     disableWordPopover: scriptureSettings_.disableWordPopover,
   }

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -85,6 +85,7 @@ export function useScriptureSettings({
   disableWordPopover,
   originalLanguageOwner,
   setUrlError,
+  timeout,
 }) {
   const isNewTestament = isNT(bookId)
   const scriptureDefaultSettings = getScriptureObject({
@@ -131,7 +132,8 @@ export function useScriptureSettings({
     }
   }, [languageId, owner, cleanUp])
 
-  const scriptureConfig = useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament, languageId, owner)
+  const scriptureConfig = useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament,
+    languageId, owner, timeout)
 
   const setScripture = (item, validationCB = null) => {
     let url

--- a/yarn.lock
+++ b/yarn.lock
@@ -10273,10 +10273,10 @@ transform-runtime@0.0.0:
   resolved "https://registry.yarnpkg.com/transform-runtime/-/transform-runtime-0.0.0.tgz#e714d9b69211dd9537939d50e3aa5788c442b85c"
   integrity sha1-5xTZtpIR3ZU3k51Q46pXiMRCuFw=
 
-translation-helps-rcl@1.46.19:
-  version "1.46.19"
-  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-1.46.19.tgz#11f11b33ace2efc286e56a96be24818de24b5ae0"
-  integrity sha512-6418/zSXzcfNtNaXyB5HDqZSaYICTisTyx3FS60EQFOE7R+F3gAdbEGE5sZWcKgpP0FA4FhNQVTk+TcpBFXAYA==
+translation-helps-rcl@1.47.0:
+  version "1.47.0"
+  resolved "https://registry.yarnpkg.com/translation-helps-rcl/-/translation-helps-rcl-1.47.0.tgz#0b11b835afed914c0c04b332a383ca759999d344"
+  integrity sha512-TA64pjsH0ken/yjMzrA8Vq1LJ1FXjWwAxaVU+Df4k9lobKkaTwhm6tW/U32/bX7dHDJyo5GyPrIdsgTVrmdaWg==
   dependencies:
     axios "^0.21.1"
     react-draggable "^4.4.3"


### PR DESCRIPTION
## Describe what your pull request addresses
- added timeout support

## Test Instructions
- note this is tricky, it is checking for internet disconnects (not WIFI or Ethernet disconnects).  In my setup I have a cable modem connected to a WiFi router, so I have three ways to generate internet disconnects (easiest first):
- test with https://deploy-preview-217--gateway-edit.netlify.app/
  1. unplugging Ethernet cable between cable modem and WIFI router
  2. Using WIFI router admin setup, disable WAN connection
  3. unscrew cable from cable modem (reconnects are very slow due to how long it takes the modem to resync)
- test network error handling while loading trans helps repos:
  - [ ] launch app and login
  - [ ] set org to `test_org`, and `en`, set to tit 1:4, all panes should be showing content
  - [ ] change language to `ru` (should see everything but tQ since it is not in tsv)
  - test network connection error when loading another book:
    - [ ] unplug internet and change book to `jon`, 
    - [ ] after about 10 sec delay should see popup of network connection error

  <img width="549" alt="Screen Shot 2021-05-20 at 8 59 36 AM" src="https://user-images.githubusercontent.com/14238574/118982872-d7405200-b949-11eb-8f12-4d27d2fa65ff.png">

    - [ ] plug in internet  and click cancel
    - [ ] screens should load, but should see this because there are bad characters in support reference, but since network is connected should not see network disconnected popup:

    <img width="1205" alt="Screen Shot 2021-05-20 at 8 45 45 AM" src="https://user-images.githubusercontent.com/14238574/118981405-4d43b980-b948-11eb-8ad2-631b6f200c40.png">  

  - [ ] change tN to 2 of 5 and tA article should load
- testing network error handling loading helps articles
  - [ ] you should still be at jon 1:1. unplug internet 
  - [ ] change vs to 17 and after about 10 sec should eventually see network error:

  <img width="549" alt="Screen Shot 2021-05-20 at 8 59 36 AM" src="https://user-images.githubusercontent.com/14238574/118982872-d7405200-b949-11eb-8f12-4d27d2fa65ff.png">

  - [ ] plug in internet  and click retry.  Page should reload

- test network error handling while clicking links:
  - [ ] change ref to `tit 1:3`, change tN to 2 of 6.
  - [ ] unplug internet  and click this link on tA:

  <img width="707" alt="Screen Shot 2021-05-20 at 9 08 53 AM" src="https://user-images.githubusercontent.com/14238574/118986970-ce517f80-b94d-11eb-86c5-7878c4111f76.png">

  - [ ] after about 5 sec, should see a load error popup

![Screen Shot 2021-05-27 at 4 17 38 PM](https://user-images.githubusercontent.com/14238574/119892279-fae63800-bf07-11eb-81f2-8d61f6603c87.png)

  - [ ] after another 5 sec, should see a network error popup

  <img width="549" alt="Screen Shot 2021-05-20 at 8 59 36 AM" src="https://user-images.githubusercontent.com/14238574/118987087-efb26b80-b94d-11eb-8918-047453946924.png">

  - [ ] plug in internet , click cancel
  - [ ] click x on this dialog:

![Screen Shot 2021-05-27 at 4 17 38 PM](https://user-images.githubusercontent.com/14238574/119892279-fae63800-bf07-11eb-81f2-8d61f6603c87.png)

  - [ ] change ref to `tit 1:3`, change tN to 2 of 6.
  - [ ] click tA link again and it should load this time

- unplug internet
  - [ ] go to account setup
  - [ ] should eventually see networking error in about 10 sec


- plug in internet
  - [ ] once network shows connected, click retry
  - [ ] this time should be no error and orgs should load

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/single-scripture-rcl/29)
<!-- Reviewable:end -->
