### PR TITLE
Feature/add support for fetching original languages from given path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.0.5",
+  "version": "2.0.6-alpha",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.0.6-alpha.2",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.0.6-alpha",
+  "version": "2.0.6-alpha.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -44,6 +44,8 @@ export default function ScriptureCard({
   disableWordPopover,
   onResourceError,
   timeout,
+  greekRepoUrl,
+  hebrewRepoUrl,
 }) {
   const [urlError, setUrlError] = React.useState(null)
   const [fontSize, setFontSize] = useUserLocalStorage(KEY_FONT_SIZE_BASE + cardNum, 100)
@@ -69,6 +71,8 @@ export default function ScriptureCard({
     originalLanguageOwner,
     setUrlError,
     timeout,
+    greekRepoUrl,
+    hebrewRepoUrl,
   })
 
   let scriptureTitle
@@ -232,4 +236,8 @@ ScriptureCard.propTypes = {
   onResourceError: PropTypes.func,
   /** optional http timeout in milliseconds for fetching resources, default is 0 (very long wait) */
   timeout: PropTypes.number,
+  /** optional url for greek repo */
+  greekRepoUrl: PropTypes.string,
+  /** optional url for hebrew repo */
+  hebrewRepoUrl: PropTypes.string,
 }

--- a/src/hooks/useScripture.tsx
+++ b/src/hooks/useScripture.tsx
@@ -41,7 +41,7 @@ export function useScripture({
   const [initialized, setInitialized] = useState(false)
   let resourceLink = resourceLink_
 
-  if (resource_) {
+  if (!resourceLink_ && resource_) {
     const {
       owner, languageId, projectId, branch = 'master',
     } = resource_ || {}

--- a/src/hooks/useScripture.tsx
+++ b/src/hooks/useScripture.tsx
@@ -52,7 +52,13 @@ export function useScripture({
 
   const {
     state: {
-      bibleJson, matchedVerse, resource, content, loadingResource, loadingContent,
+      bibleJson,
+      matchedVerse,
+      resource,
+      content,
+      loadingResource,
+      loadingContent,
+      fetchResponse,
     },
   } = useRsrc({
     config, reference, resourceLink, options,
@@ -98,5 +104,6 @@ export function useScripture({
     matchedVerse,
     verseObjects,
     resourceStatus,
+    fetchResponse,
   }
 }

--- a/src/hooks/useScriptureResources.tsx
+++ b/src/hooks/useScriptureResources.tsx
@@ -8,13 +8,15 @@ import { getScriptureResourceSettings } from '../utils/ScriptureSettings'
  * @param {string} chapter
  * @param {string} verse
  * @param {boolean} isNewTestament
+ * @param {string} originalRepoUrl - optional path to repo for original language
  * @param {string} currentLanguageId - optional over-ride for transient case where language in scripture settings have not yet updated
  * @param {string} currentOwner - optional over-ride for transient case where owner in scripture settings have not yet updated
  * @param {number} timeout - optional http timeout in milliseconds for fetching resources, default is 10 sec
  */
-export function useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament,
+export function useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament, originalRepoUrl=null,
                                       currentLanguageId=null, currentOwner=null, timeout=10000) {
-  const scriptureSettings_ = getScriptureResourceSettings(bookId, scriptureSettings, isNewTestament, currentLanguageId, currentOwner) // convert any default settings strings
+  const scriptureSettings_ = getScriptureResourceSettings(bookId, scriptureSettings, isNewTestament,
+    originalRepoUrl, currentLanguageId, currentOwner) // convert any default settings strings
 
   const scriptureConfig_ = {
     reference: {

--- a/src/hooks/useScriptureResources.tsx
+++ b/src/hooks/useScriptureResources.tsx
@@ -33,7 +33,7 @@ export function useScriptureResources(bookId, scriptureSettings, chapter, verse,
     resourceLink: scriptureSettings_.resourceLink,
     config: {
       server: scriptureSettings_.server,
-      cache: { maxAge: 60 * 1000 },
+      cache: { maxAge: 1 * 60 * 60 * 1000 }, // 1 hr
       timeout,
     },
     disableWordPopover: scriptureSettings_.disableWordPopover,

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -86,6 +86,8 @@ export function useScriptureSettings({
   originalLanguageOwner,
   setUrlError,
   timeout,
+  greekRepoUrl,
+  hebrewRepoUrl,
 }) {
   const isNewTestament = isNT(bookId)
   const scriptureDefaultSettings = getScriptureObject({
@@ -132,8 +134,9 @@ export function useScriptureSettings({
     }
   }, [languageId, owner, cleanUp])
 
-  const scriptureConfig = useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament,
-    languageId, owner, timeout)
+  const originalRepoUrl = isNewTestament ? greekRepoUrl : hebrewRepoUrl
+  const scriptureConfig = useScriptureResources(bookId, scriptureSettings,chapter, verse, isNewTestament,
+    originalRepoUrl, languageId, owner, timeout)
 
   const setScripture = (item, validationCB = null) => {
     let url
@@ -167,7 +170,7 @@ export function useScriptureSettings({
       let url_ = item.url
 
       if (!url) { // if not a new resource
-        scriptureSettings = getScriptureResourceSettings(resourceId, bookId, isNewTestament) // convert any default settings strings
+        scriptureSettings = getScriptureResourceSettings(resourceId, bookId, isNewTestament, originalRepoUrl) // convert any default settings strings
         url_ = scriptureSettings.resourceLink
       }
 

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -184,7 +184,7 @@ export function useScriptureSettings({
         },
         config: {
           server: server_,
-          cache: { maxAge: 60 * 1000 },
+          cache: { maxAge: 1 * 60 * 60 * 1000 }, // 1 hr
         },
       }).then(resource => {
         let error = REPO_NOT_FOUND_ERROR

--- a/src/utils/ScriptureSettings.ts
+++ b/src/utils/ScriptureSettings.ts
@@ -90,10 +90,13 @@ export function cleanupAccountSettings(scriptureSettings: any, currentOwner: any
  * @param {string} originalRepoUrl
  */
 export function splitUrl(originalRepoUrl) {
-  const url = new URL(originalRepoUrl)
-  const server = url.origin
-  const resourceLink = url.pathname + (url.search || '')
-  return { server, resourceLink }
+  if (originalRepoUrl) {
+    const url = new URL(originalRepoUrl)
+    const server = url.origin
+    const resourceLink = url.pathname + (url.search || '')
+    return { server, resourceLink }
+  }
+  return {}
 }
 
 /**

--- a/src/utils/ScriptureSettings.ts
+++ b/src/utils/ScriptureSettings.ts
@@ -86,14 +86,29 @@ export function cleanupAccountSettings(scriptureSettings: any, currentOwner: any
 }
 
 /**
+ * separate URL into server and resource link
+ * @param {string} originalRepoUrl
+ */
+export function splitUrl(originalRepoUrl) {
+  const url = new URL(originalRepoUrl)
+  const server = url.origin
+  const resourceLink = url.pathname + (url.search || '')
+  return { server, resourceLink }
+}
+
+/**
  * get the scripture settings needed for fetch - for OrigLang, ULT, GLT will replace owner and languageId with correct values
  * @param {string} bookId
  * @param {object} scriptureSettings_
  * @param {boolean} isNewTestament
+ * @param {string} originalRepoUrl - optional path to repo for original language
  * @param {string} currentLanguageId - optional over-ride for transient case where language in scripture settings have not yet updated
  * @param {string} currentOwner - optional over-ride for transient case where owner in scripture settings have not yet updated
  */
-export function getScriptureResourceSettings(bookId, scriptureSettings_, isNewTestament, currentLanguageId=null, currentOwner=null) {
+export function getScriptureResourceSettings(bookId, scriptureSettings_, isNewTestament,
+                                             originalRepoUrl=null,
+                                             currentLanguageId=null, currentOwner=null
+) {
   const scriptureSettings = { ...scriptureSettings_ }
   scriptureSettings.disableWordPopover = DISABLE_WORD_POPOVER
   const resourceId = scriptureSettings_.resourceId
@@ -109,7 +124,13 @@ export function getScriptureResourceSettings(bookId, scriptureSettings_, isNewTe
       scriptureSettings.owner = scriptureSettings.originalLanguageOwner
     }
 
-    scriptureSettings.resourceLink = getResourceLink(scriptureSettings)
+    if (originalRepoUrl) { // if we already have the actual URL
+      const { server, resourceLink } = splitUrl(originalRepoUrl)
+      scriptureSettings.server = server
+      scriptureSettings.resourceLink = resourceLink
+    } else {
+      scriptureSettings.resourceLink = getResourceLink(scriptureSettings)
+    }
     scriptureSettings.disableWordPopover = false
   } else if (resourceId === TARGET_LITERAL) {
     cleanupAccountSettings(scriptureSettings, currentOwner, currentLanguageId)

--- a/src/utils/ScriptureSettings.ts
+++ b/src/utils/ScriptureSettings.ts
@@ -127,11 +127,11 @@ export function getScriptureResourceSettings(bookId, scriptureSettings_, isNewTe
       scriptureSettings.owner = scriptureSettings.originalLanguageOwner
     }
 
-    if (originalRepoUrl) { // if we already have the actual URL
+    if (originalRepoUrl) { // use this url if defined
       const { server, resourceLink } = splitUrl(originalRepoUrl)
       scriptureSettings.server = server
       scriptureSettings.resourceLink = resourceLink
-    } else {
+    } else { // fall back to app defaults
       scriptureSettings.resourceLink = getResourceLink(scriptureSettings)
     }
     scriptureSettings.disableWordPopover = false


### PR DESCRIPTION
## Describe what your pull request addresses
- [ ] changes to use urls for greek and hebrew original language if passed in props
- [ ] useScripture now returns the fetch response
- [ ] increase cache duration for resources

## Test Instructions
- test with https://deploy-preview-233--gateway-edit.netlify.app/
- [ ] run app with test_org, en to make sure app still works
- [ ] check console log, it should have entries for ugnt such as `fetch & parse unfoldingWord/el-x-koine/ugnt/v0.20/mat` and not `fetch & parse unfoldingWord/el-x-koine/ugnt/master/mat`.  Or in the case of OT books should have entries for uhb such as: `fetch & parse unfoldingWord/hbo/uhb/v2.1.19/deu`
- [ ] check localStorage it should have entries:
  - [ ] greekRepoUrl: "https://git.door43.org/api/v1/repos/unfoldingWord/el-x-koine_ugnt/contents?ref=v0.20"
  - [ ] hebrewRepoUrl:"https://git.door43.org/api/v1/repos/unfoldingWord/hbo_uhb/contents?ref=v2.1.19"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/single-scripture-rcl/30)
<!-- Reviewable:end -->
