### PR TITLE
Feature/add branch and tag support 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.2.0-alpha.3",
+  "version": "2.2.0-alpha.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.2.0-alpha.5",
+  "version": "3.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.2.0-alpha.4",
+  "version": "2.2.0-alpha.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"
@@ -24,7 +24,7 @@
     "prop-types": "^15.x",
     "react": "^17.x",
     "react-dom": "^17.x",
-    "scripture-resources-rcl": "^4.x",
+    "scripture-resources-rcl": "^5.x",
     "translation-helps-rcl": "^1.x"
   },
   "devDependencies": {
@@ -61,7 +61,7 @@
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-styleguidist": "^11.1.5",
-    "scripture-resources-rcl": "4.1.8",
+    "scripture-resources-rcl": "5.0.0",
     "style-loader": "^2.0.0",
     "translation-helps-rcl": "1.47.0",
     "webpack": "^4.44.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.2.0-alpha.2",
+  "version": "2.2.0-alpha.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.2.0-alpha",
+  "version": "2.2.0-alpha.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "2.1.0",
+  "version": "2.2.0-alpha",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -220,7 +220,7 @@ ScriptureCard.propTypes = {
   /** server (e.g. 'https://git.door43.org') */
   server: PropTypes.string.isRequired,
   /** repo branch or tag such as master */
-  ref: PropTypes.string.isRequired,
+  appRef: PropTypes.string.isRequired,
   /** if true then word data hover is shown */
   disableWordPopover: PropTypes.bool,
   /** CSS classes */

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -24,7 +24,7 @@ export default function ScriptureCard({
   isNT,
   title,
   server,
-  branch,
+  appRef,
   cardNum,
   classes,
   resource: {
@@ -43,7 +43,7 @@ export default function ScriptureCard({
   useUserLocalStorage,
   disableWordPopover,
   onResourceError,
-  timeout,
+  httpConfig,
   greekRepoUrl,
   hebrewRepoUrl,
 }) {
@@ -59,7 +59,7 @@ export default function ScriptureCard({
     verse,
     owner,
     bookId,
-    branch,
+    appRef,
     server,
     cardNum,
     chapter,
@@ -70,7 +70,7 @@ export default function ScriptureCard({
     disableWordPopover,
     originalLanguageOwner,
     setUrlError,
-    timeout,
+    httpConfig,
     greekRepoUrl,
     hebrewRepoUrl,
   })
@@ -219,8 +219,8 @@ ScriptureCard.propTypes = {
   }),
   /** server (e.g. 'https://git.door43.org') */
   server: PropTypes.string.isRequired,
-  /** repo branch such as master */
-  branch: PropTypes.string.isRequired,
+  /** repo branch or tag such as master */
+  ref: PropTypes.string.isRequired,
   /** if true then word data hover is shown */
   disableWordPopover: PropTypes.bool,
   /** CSS classes */
@@ -235,7 +235,7 @@ ScriptureCard.propTypes = {
    *      - resourceStatus - is object containing details about problems fetching resource */
   onResourceError: PropTypes.func,
   /** optional http timeout in milliseconds for fetching resources, default is 0 (very long wait) */
-  timeout: PropTypes.number,
+  httpConfig: PropTypes.object,
   /** optional url for greek repo */
   greekRepoUrl: PropTypes.string,
   /** optional url for hebrew repo */

--- a/src/hooks/useScripture.tsx
+++ b/src/hooks/useScripture.tsx
@@ -43,9 +43,15 @@ export function useScripture({
 
   if (!resourceLink_ && resource_) {
     const {
-      owner, languageId, projectId, branch = 'master',
+      owner,
+      languageId,
+      projectId,
+      branch = 'master',
+      ref = null,
     } = resource_ || {}
-    resourceLink = getResourceLinkSpecific(owner, languageId, projectId, branch)
+    const ref_ = ref || branch
+    resourceLink = getResourceLinkSpecific(owner, languageId, projectId, ref_)
+    console.log(`useTsvItems - resourceLink: ${resourceLink}, resource_:`, resource_)
   }
 
   const options = { getBibleJson: true }

--- a/src/hooks/useScripture.tsx
+++ b/src/hooks/useScripture.tsx
@@ -51,7 +51,6 @@ export function useScripture({
     } = resource_ || {}
     const ref_ = ref || branch
     resourceLink = getResourceLinkSpecific(owner, languageId, projectId, ref_)
-    console.log(`useTsvItems - resourceLink: ${resourceLink}, resource_:`, resource_)
   }
 
   const options = { getBibleJson: true }

--- a/src/hooks/useScriptureResources.tsx
+++ b/src/hooks/useScriptureResources.tsx
@@ -11,10 +11,21 @@ import { getScriptureResourceSettings } from '../utils/ScriptureSettings'
  * @param {string} originalRepoUrl - optional path to repo for original language
  * @param {string} currentLanguageId - optional over-ride for transient case where language in scripture settings have not yet updated
  * @param {string} currentOwner - optional over-ride for transient case where owner in scripture settings have not yet updated
- * @param {number} timeout - optional http timeout in milliseconds for fetching resources, default is 10 sec
+ * @param {object} httpConfig - optional config settings for fetches (timeout, cache, etc.)
+ * @param {string} appRef - app default, points to specific ref that could be a branch or tag
  */
-export function useScriptureResources(bookId, scriptureSettings, chapter, verse, isNewTestament, originalRepoUrl=null,
-                                      currentLanguageId=null, currentOwner=null, timeout=10000) {
+export function useScriptureResources({
+  bookId,
+  scriptureSettings,
+  chapter,
+  verse,
+  isNewTestament,
+  originalRepoUrl,
+  currentLanguageId = null,
+  currentOwner = null,
+  httpConfig = {},
+  appRef = 'master',
+}) {
   const scriptureSettings_ = getScriptureResourceSettings(bookId, scriptureSettings, isNewTestament,
     originalRepoUrl, currentLanguageId, currentOwner) // convert any default settings strings
 
@@ -28,13 +39,12 @@ export function useScriptureResources(bookId, scriptureSettings, chapter, verse,
       languageId: scriptureSettings_.languageId,
       projectId: scriptureSettings_.resourceId,
       owner: scriptureSettings_.owner,
-      branch: scriptureSettings_.branch,
+      ref: scriptureSettings_.ref || scriptureSettings_.branch || appRef,
     },
     resourceLink: scriptureSettings_.resourceLink,
     config: {
       server: scriptureSettings_.server,
-      cache: { maxAge: 1 * 60 * 60 * 1000 }, // 1 hr
-      timeout,
+      ...httpConfig,
     },
     disableWordPopover: scriptureSettings_.disableWordPopover,
   }

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -50,7 +50,7 @@ function fixScriptureSettings(versionHist, scriptureSettings, languageId, cardNu
     const resourceId = item.resourceId
 
     if ((resourceId === NT_ORIG_LANG_BIBLE) || (resourceId === OT_ORIG_LANG_BIBLE) || (resourceId === ORIGINAL_SOURCE)) {
-      for ( let j = i + 1; j < history.length; j++) {
+      for ( let j = i + 1; j < history.length; j++) { // search rest of list for duplicates of item at i
         const match_item = history[j]
         const match_resourceId = match_item.resourceId
 

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -7,8 +7,10 @@ import {
   INVALID_URL,
   MANIFEST_INVALID_SHORT_ERROR,
   NT_ORIG_LANG_BIBLE,
+  NT_ORIG_LANG,
   ORIGINAL_SOURCE,
   OT_ORIG_LANG_BIBLE,
+  OT_ORIG_LANG,
   REPO_NOT_FOUND_ERROR,
   REPO_NOT_SCRIPTURE_ERROR,
   setLocalStorageValue,
@@ -28,18 +30,19 @@ const KEY_TARGET_BASE = 'scripturePaneTarget_'
 function fixScriptureSettings(versionHist, scriptureSettings, languageId, cardNum, owner) {
   // clean up hard-coded original sources
   if ((scriptureSettings.resourceId === NT_ORIG_LANG_BIBLE) || (scriptureSettings.resourceId === OT_ORIG_LANG_BIBLE)) {
-    const newScriptureSettings = { ...scriptureSettings }
-    newScriptureSettings.languageId = languageId
-    newScriptureSettings.resourceId = ORIGINAL_SOURCE
-    newScriptureSettings.owner = owner
-    newScriptureSettings.resourceLink = getResourceLink(newScriptureSettings)
-    setLocalStorageValue(KEY_SETTINGS_BASE + cardNum, newScriptureSettings)
-    versionHist.addItemToHistory(newScriptureSettings)
+    if ((scriptureSettings.languageId !== NT_ORIG_LANG) && (scriptureSettings.languageId !== OT_ORIG_LANG)) { // if this is track with current selected language and testament of book
+      const newScriptureSettings = { ...scriptureSettings }
+      newScriptureSettings.languageId = languageId
+      newScriptureSettings.resourceId = ORIGINAL_SOURCE
+      newScriptureSettings.owner = owner
+      newScriptureSettings.resourceLink = getResourceLink(newScriptureSettings)
+      setLocalStorageValue(KEY_SETTINGS_BASE + cardNum, newScriptureSettings)
+      versionHist.addItemToHistory(newScriptureSettings)
+    }
   }
 
   // clean history of original sources
   let history = versionHist.getLatest() || []
-  let first = -1
   let modified = false
 
   for (let i = 0; i < history.length; i++) { // search for original source duplicates in history
@@ -47,12 +50,20 @@ function fixScriptureSettings(versionHist, scriptureSettings, languageId, cardNu
     const resourceId = item.resourceId
 
     if ((resourceId === NT_ORIG_LANG_BIBLE) || (resourceId === OT_ORIG_LANG_BIBLE) || (resourceId === ORIGINAL_SOURCE)) {
-      if (first < 0) {
-        first = i
-      } else { // found duplicate
-        history.splice(i, 1) // remove duplicate item
-        modified = true
-        i--
+      for ( let j = i + 1; j < history.length; j++) {
+        const match_item = history[j]
+        const match_resourceId = match_item.resourceId
+
+        if ((match_resourceId === resourceId)) {
+          if ((item.owner === match_item.owner) &&
+            (item.ref === match_item.ref) &&
+            (item.server === match_item.server) &&
+            (item.resourceId === match_item.resourceId)) {
+            history.splice(j, 1) // remove duplicate item
+            modified = true
+            j-- // back up index since contents shifted
+          }
+        }
       }
     }
   }
@@ -218,7 +229,7 @@ export function useScriptureSettings({
               title,
               server: server_,
               owner: resource.username,
-              branch: resource.tag,
+              ref: resource.ref || 'master',
               languageId: resource.languageId,
               resourceId: resource.resourceId,
               resourceLink: resource.resourceLink,

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -77,7 +77,7 @@ export function useScriptureSettings({
   bookId,
   owner,
   server,
-  branch,
+  appRef,
   languageId,
   resourceId,
   resourceLink,
@@ -85,7 +85,7 @@ export function useScriptureSettings({
   disableWordPopover,
   originalLanguageOwner,
   setUrlError,
-  timeout,
+  httpConfig,
   greekRepoUrl,
   hebrewRepoUrl,
 }) {
@@ -94,7 +94,7 @@ export function useScriptureSettings({
     title,
     server,
     owner,
-    branch,
+    ref: appRef,
     languageId,
     resourceId,
     resourceLink,
@@ -135,8 +135,18 @@ export function useScriptureSettings({
   }, [languageId, owner, cleanUp])
 
   const originalRepoUrl = isNewTestament ? greekRepoUrl : hebrewRepoUrl
-  const scriptureConfig = useScriptureResources(bookId, scriptureSettings,chapter, verse, isNewTestament,
-    originalRepoUrl, languageId, owner, timeout)
+  const scriptureConfig = useScriptureResources({
+    bookId,
+    scriptureSettings,
+    chapter,
+    verse,
+    isNewTestament,
+    originalRepoUrl,
+    currentLanguageId: languageId,
+    currentOwner: owner,
+    httpConfig,
+    appRef,
+  })
 
   const setScripture = (item, validationCB = null) => {
     let url

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -16,6 +16,7 @@ export interface ScriptureResource {
   projectId: string;
   owner: string;
   branch: string;
+  ref: string;
 }
 
 export interface VerseObjectType {

--- a/src/utils/ScriptureSettings.ts
+++ b/src/utils/ScriptureSettings.ts
@@ -118,7 +118,7 @@ export function getScriptureResourceSettings(bookId, scriptureSettings_, isNewTe
   scriptureSettings.disableWordPopover = DISABLE_WORD_POPOVER
   const resourceId = scriptureSettings_.resourceId
 
-  if ((resourceId === ORIGINAL_SOURCE) || (resourceId === NT_ORIG_LANG_BIBLE) || (resourceId === OT_ORIG_LANG_BIBLE)) {
+  if (resourceId === ORIGINAL_SOURCE) {
     // select original language Bible based on which testament the book belongs
     scriptureSettings.languageId = isNewTestament ? NT_ORIG_LANG : OT_ORIG_LANG
     scriptureSettings.resourceId = isNewTestament

--- a/src/utils/ScriptureSettings.ts
+++ b/src/utils/ScriptureSettings.ts
@@ -23,14 +23,15 @@ import {
 export const DISABLE_WORD_POPOVER = true // disable word popover for every scripture pane but original languages
 
 export function getResourceLink(scripture) {
-  return `${scripture.owner}/${scripture.languageId}/${scripture.resourceId}/${scripture.branch}`
+  const ref = scripture.ref || scripture.branch
+  return `${scripture.owner}/${scripture.languageId}/${scripture.resourceId}/${ref}`
 }
 
 export function getScriptureObject({
   title,
   server,
   owner,
-  branch,
+  ref,
   languageId,
   resourceId,
   resourceLink,
@@ -42,7 +43,7 @@ export function getScriptureObject({
     server,
     owner,
     originalLanguageOwner,
-    branch,
+    ref,
     languageId,
     resourceId,
     disableWordPopover,
@@ -52,7 +53,7 @@ export function getScriptureObject({
   if (!resourceLink) {
     scripture.resourceLink = getResourceLink({
       owner,
-      branch,
+      ref,
       languageId,
       resourceId,
     })
@@ -110,7 +111,8 @@ export function splitUrl(originalRepoUrl) {
  */
 export function getScriptureResourceSettings(bookId, scriptureSettings_, isNewTestament,
                                              originalRepoUrl=null,
-                                             currentLanguageId=null, currentOwner=null
+                                             currentLanguageId=null,
+                                             currentOwner=null,
 ) {
   const scriptureSettings = { ...scriptureSettings_ }
   scriptureSettings.disableWordPopover = DISABLE_WORD_POPOVER
@@ -308,9 +310,9 @@ export function getResourceMessage(resourceStatus: object, server: string, resou
  * @param owner
  * @param languageId
  * @param projectId
- * @param branch
+ * @param ref
  */
-export function getResourceLinkSpecific(owner: string, languageId: string, projectId: string, branch: string) {
-  return `${owner}/${languageId}/${projectId}/${branch}`
+export function getResourceLinkSpecific(owner: string, languageId: string, projectId: string, ref: string) {
+  return `api/v1/repos/${owner}/${languageId}_${projectId}/contents?ref=${ref}`
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9266,10 +9266,10 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-scripture-resources-rcl@4.1.8:
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/scripture-resources-rcl/-/scripture-resources-rcl-4.1.8.tgz#6766c910b854ae8dae6c9fba482c16324447b686"
-  integrity sha512-8r09/AG3Olw+byv5M2SVUrjtIpouRH7zLIg18dVDf0LTreKV6Lc3xIjbxzTOIjFpzSRChIIdm2hOeiwFKB4sGw==
+scripture-resources-rcl@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/scripture-resources-rcl/-/scripture-resources-rcl-5.0.0.tgz#b88bf4dda1b6d30ff8b50d44dcf764c690fbddc1"
+  integrity sha512-B6N4NfN2hi/7f1SgN+H7hsdmWjgNt+UReZlA1lYsNTRMAv6/fAyZjfz86F3tOPh+XO/zxf5LFrSbO+tG2GwmDw==
   dependencies:
     deep-freeze "^0.0.1"
     gitea-react-toolkit "1.7.0"


### PR DESCRIPTION
## Describe what your pull request addresses
part of https://github.com/unfoldingword/gateway-edit/issues/231
- [ ] switched from using branch parameter to using refs that can be a branch or tag
- [ ] replaced timeout parameter with httpConfig which can contain a variety of http options including timeout and caching.

## Test Instructions
- test with https://deploy-preview-250--gateway-edit.netlify.app/

- [ ] login, use test_org/en and set book to **tit 1:1**
- [ ] on one of the scripture panes, set version source to: `https://git.door43.org/photonomad1/el-x-koine_ugnt/src/branch/photonomad1-patch-1` and should see loaded in pane:

<img width="459" alt="Screen Shot 2021-06-29 at 4 02 32 PM" src="https://user-images.githubusercontent.com/14238574/123862116-f392bf80-d8f5-11eb-9fb4-74a5de008044.png">

- [ ] on one of the scripture panes, set version source to: `https://git.door43.org/photonomad1/el-x-koine_ugnt/src/tag/tag-test` and should see loaded in pane:

<img width="477" alt="Screen Shot 2021-06-29 at 4 07 12 PM" src="https://user-images.githubusercontent.com/14238574/123860949-934f4e00-d8f4-11eb-86c9-f837108f0799.png">

- [ ] edit local storage and set `<user>_resource_card_tn_ref` to `photonomad1-patch-1`.  Reload page and the first tn article for 1:1 should show under Note: 

<img width="718" alt="Screen Shot 2021-06-29 at 4 14 06 PM" src="https://user-images.githubusercontent.com/14238574/123861448-2f795500-d8f5-11eb-9274-4b8839101a88.png">

- [ ] edit local storage and set `<user>_resource_card_ta_ref` to `photonomad1-patch-1`.  Reload page and with the first tn article for 1:1 selected, tA article should show: `More testing: Abstract nouns...`

<img width="673" alt="Screen Shot 2021-06-29 at 4 16 34 PM" src="https://user-images.githubusercontent.com/14238574/123862299-2dfc5c80-d8f6-11eb-81d1-a99e1e091777.png">

- [ ] edit local storage and set `<user>_resource_card_twl_ref` to `photonomad1-patch-1`.  Reload page and with 1:1, twl should show a second occurrence of Paul:

<img width="359" alt="Screen Shot 2021-06-29 at 4 23 39 PM" src="https://user-images.githubusercontent.com/14238574/123862535-7287f800-d8f6-11eb-8a12-b397173f4944.png">

- [ ] edit local storage and set `<user>_resource_card_twa_ref` to `photonomad1-patch-1`.  Reload page and with first Paul selected for 1:1, twa should show:

<img width="542" alt="Screen Shot 2021-06-29 at 4 24 58 PM" src="https://user-images.githubusercontent.com/14238574/123862678-a4995a00-d8f6-11eb-9865-fdaf0d4c6771.png">

- [ ] edit local storage and set `<user>_resource_card_tq_ref` to `photonomad1-patch-1`.  Reload page and for 1:1, tq should show:

<img width="536" alt="Screen Shot 2021-06-29 at 4 27 06 PM" src="https://user-images.githubusercontent.com/14238574/123863023-0c4fa500-d8f7-11eb-9b09-4906885247dd.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/single-scripture-rcl/31)
<!-- Reviewable:end -->
