### PR TITLE
Feature 228/add support for more urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.0.0",
+  "version": "3.0.1-alpha.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.0.1-alpha.2",
+  "version": "3.0.1-alpha.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.0.1-alpha.3",
+  "version": "3.0.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -188,7 +188,7 @@ export function useScriptureSettings({
     if (newUrl) {
       setUrlError(null) // clear previous warnings
 
-      // handle: git@git.door43.org:unfoldingWord/en_ult.git
+      // handle: `git@git.door43.org:unfoldingWord/en_ult.git`
       //    by mapping to https git fetch url (e.g. https://git.door43.org:unfoldingWord/en_ult.git)
       if (newUrl?.includes('git@')) {
         const parts = newUrl?.split(':')

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -159,6 +159,26 @@ export function useScriptureSettings({
     appRef,
   })
 
+  /**
+   * make sure that bookId or projectId are not embedded in link
+   * @param {string} resourceLink
+   * @return {string} - cleaned up resource link
+   */
+  function cleanResourceLink(resourceLink) {
+    let resourceLink_ = resourceLink
+    const resourceLinks = resourceLink_?.split('/')
+
+    if (resourceLinks?.length > 4) {
+      resourceLink_ = resourceLinks?.slice(0, 4).join('/')
+    }
+    return resourceLink_
+  }
+
+  /**
+   * callback to either add new scripture item or select existing item in history
+   * @param {object} item - new item to add or existing item to select from history
+   * @param {function} validationCB - callback function to pass back if item url was valid or not
+   */
   const setScripture = (item, validationCB = null) => {
     let url
     let newUrl = item?.url
@@ -167,7 +187,7 @@ export function useScriptureSettings({
       setUrlError(null) // clear previous warnings
 
       // handle: git@git.door43.org:unfoldingWord/en_ult.git
-      //    by mapping to https git fetch url
+      //    by mapping to https git fetch url (e.g. https://git.door43.org:unfoldingWord/en_ult.git)
       if (newUrl?.includes('git@')) {
         const parts = newUrl?.split(':')
         const [, hostname] = parts[0].split('@')
@@ -191,9 +211,9 @@ export function useScriptureSettings({
       let hostname = url.hostname
 
       if (hostname) {
-        if (newUrl?.includes(`/door43.org/u/`)) {
-          // handle case of link to d43 reader page https://door43.org/u/unfoldingWord/en_ult/
-          hostname = 'git.' + hostname // redirect to repo
+        if (hostname === `door43.org`) {
+          // handle case of link to d43 reader page (e.g. https://door43.org/u/unfoldingWord/en_ult/)
+          hostname = 'git.' + hostname // redirect to git repo
         }
 
         if (url.port) {
@@ -246,7 +266,7 @@ export function useScriptureSettings({
               ref: resource.ref || 'master',
               languageId: resource.languageId,
               resourceId: resource.resourceId,
-              resourceLink: resource.resourceLink,
+              resourceLink: cleanResourceLink(resource?.resourceLink),
               disableWordPopover,
               originalLanguageOwner,
             })

--- a/src/hooks/useScriptureSettings.tsx
+++ b/src/hooks/useScriptureSettings.tsx
@@ -160,7 +160,9 @@ export function useScriptureSettings({
   })
 
   /**
-   * make sure that bookId or projectId are not embedded in link
+   * make sure that bookId or projectId are not embedded in link.
+   *    For example in `ru_gl/ru/rsob/master/heb` the projectId heb is in the link and will override the
+   *    projectId in the reference when we try to fetch later
    * @param {string} resourceLink
    * @return {string} - cleaned up resource link
    */
@@ -168,7 +170,7 @@ export function useScriptureSettings({
     let resourceLink_ = resourceLink
     const resourceLinks = resourceLink_?.split('/')
 
-    if (resourceLinks?.length > 4) {
+    if (resourceLinks?.length > 4) { // if too many fields, then trim
       resourceLink_ = resourceLinks?.slice(0, 4).join('/')
     }
     return resourceLink_


### PR DESCRIPTION
## Describe what your pull request addresses

## Describe what your pull request addresses
part of https://github.com/unfoldingword/gateway-edit/issues/228
- [ ] added support for more URL formats

## Test Instructions
- test with https://deploy-preview-265--gateway-edit.netlify.app/
- try add the following scripture urls to a scripture pane.  Make sure scripture actually shows up in scripture pane:
- [x] `https://git.door43.org/unfoldingWord/en_ult`
- [x] `https://git.door43.org/unfoldingWord/el-x-koine_ugnt/src/tag/v0.20`
- [x] `https://door43.org/u/unfoldingWord/en_ult/`
- [x] `https://git.door43.org/Door43-Catalog/en_ust.git`
- [x] `git@git.door43.org:unfoldingWord/en_ult.git`
- [x] change bible reference to heb
- [x] change a scripture pane to `https://git.door43.org/ru_gl/ru_rsob` and should see message that `This book can not be found in the project...`.  Should not get a crash
- [x] switch book to tit and should see Russian content.


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unfoldingword/single-scripture-rcl/32)
<!-- Reviewable:end -->
