### PR TITLE
Feature mcleanb 385 retry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,5 +106,8 @@ dist
 # IntelliJ config
 .idea
 
+# VsCode Plugins
+.prettierignore
+
 .yalc/
 yalc.lock

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.3.3-patch.1",
+  "version": "3.3.3-patch.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.3.3-patch.4",
+  "version": "3.3.3-patch.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.3.3-patch.5",
+  "version": "3.3.3-patch.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.3.3-patch.3",
+  "version": "3.3.3-patch.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -791,6 +791,8 @@ export default function ScriptureCard({
         </IconButton>
       )
     }
+
+    return newItems
   }
 
   return (
@@ -826,7 +828,7 @@ export default function ScriptureCard({
         editable={enableEdit || enableAlignment}
         saved={startSave || !haveUnsavedChanges}
         onSaveEdit={() => setState({ saveClicked: true })}
-      onRenderToolbar={onRenderToolbar}
+        onRenderToolbar={onRenderToolbar}
       >
         <div id="scripture-pane-list">
           {renderedScripturePanes}

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -562,6 +562,10 @@ export default function ScriptureCard({
     }
   }, [scriptureConfig?.versesForRef])
 
+  React.useEffect(() => {
+    setState({ versesAlignmentStatus: null })
+  }, [verse])
+
   const updateVersesAlignmentStatus = (reference, aligned) => {
     setState_(prevState => ({
       ...prevState,

--- a/src/components/ScripturePane/ScripturePane.tsx
+++ b/src/components/ScripturePane/ScripturePane.tsx
@@ -2,8 +2,6 @@ import * as React from 'react'
 import useDeepCompareEffect from 'use-deep-compare-effect'
 import { VerseObjects } from 'scripture-resources-rcl'
 import { UsfmFileConversionHelpers } from 'word-aligner-rcl'
-import { RxLink2, RxLinkBreak2 } from 'react-icons/rx'
-import { IconButton } from '@mui/material'
 import { ScriptureReference } from '../../types'
 import { getResourceMessage } from '../../utils'
 import { ScriptureALignmentEditProps, useScriptureAlignmentEdit } from "../../hooks/useScriptureAlignmentEdit";
@@ -44,6 +42,12 @@ interface Props {
   setWordAlignerStatus: Function;
   /** optional function for localization */
   translate: Function;
+  /** whether or not this current verse has been selected for alignment */
+  isVerseSelectedForAlignment: boolean;
+  /** function to be called when verse alignment has finished */
+  onAlignmentFinish: Function;
+  /** function to be called to update verse alignment status */
+  updateVersesAlignmentStatus: Function;
 }
 
 const MessageStyle = {
@@ -85,6 +89,9 @@ function ScripturePane({
   scriptureAlignmentEditConfig,
   setSavedChanges,
   setWordAlignerStatus,
+  isVerseSelectedForAlignment,
+  onAlignmentFinish,
+  updateVersesAlignmentStatus,
 } : Props) {
   const [state, setState_] = React.useState({
     doingAlignment: false,
@@ -139,6 +146,14 @@ function ScripturePane({
     },
   } = _scriptureAlignmentEdit
 
+  if (isVerseSelectedForAlignment && !alignerData && !doingAlignment) {
+    handleAlignmentClick()
+  }
+
+  React.useEffect(() => {
+    updateVersesAlignmentStatus(reference, aligned)
+  }, [aligned])
+
   React.useEffect(() => {
     if (alignerData && !doingAlignment) {
       setWordAlignerStatus && setWordAlignerStatus(_scriptureAlignmentEdit)
@@ -146,6 +161,7 @@ function ScripturePane({
     } else if (doingAlignment) {
       setWordAlignerStatus && setWordAlignerStatus(_scriptureAlignmentEdit)
       setState({ doingAlignment: false })
+      onAlignmentFinish && onAlignmentFinish()
     }
   }, [_scriptureAlignmentEdit?.state?.alignerData])
 
@@ -212,21 +228,6 @@ function ScripturePane({
               />
             }
           </span>
-          {setWordAlignerStatus &&
-            <IconButton
-              key='checking-button'
-              onClick={() => handleAlignmentClick()}
-              title={titleText}
-              aria-label={titleText}
-              style={{ cursor: 'pointer' }}
-            >
-              {checkingState === 'valid' ? (
-                <RxLink2 id='valid_icon' color='#BBB' />
-              ) : (
-                <RxLinkBreak2 id='invalid_icon' color='#000' />
-              )}
-            </IconButton>
-          }
         </Content>
       }
     </Container>

--- a/src/components/VerseSelectorPopup/VerseSelectorPopup.tsx
+++ b/src/components/VerseSelectorPopup/VerseSelectorPopup.tsx
@@ -1,0 +1,94 @@
+import * as React from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import { DraggableCard } from 'translation-helps-rcl'
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import { RxLink2, RxLinkBreak2 } from 'react-icons/rx'
+
+const useStyles = makeStyles(theme => ({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  list: {
+    paddingTop: theme.spacing(1),
+    paddingBottom: theme.spacing(1),
+  },
+  button: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
+    alignSelf: 'flex-end',
+  },
+}))
+
+const VerseSelectorContent = ({
+  resourceId,
+  versesForRef,
+  versesAlignmentStatus,
+  onVerseSelect,
+}) => {
+
+  const renderedVerseItems = versesForRef.map(verse => {
+    const isVerseAligned = versesAlignmentStatus?.[`${verse.chapter}:${verse.verse}`]
+    let alignIcon = null
+    if (isVerseAligned) {
+      alignIcon = <RxLink2 id={`valid_icon_${resourceId}`} color='#BBB' size={24} />
+    } else {
+      alignIcon = <RxLinkBreak2 id={`invalid_alignment_icon_${resourceId}`} color='#000' size={24} />
+    }
+
+    return (
+      <ListItem
+        disablePadding
+        id={`verse-${verse.chapter}:${verse.verse}`}
+        key={`verse-${verse.chapter}:${verse.verse}`}
+        onClick={(event) => {onVerseSelect(verse)}}
+      >
+        <ListItemButton>
+          <ListItemIcon>
+            {alignIcon}
+          </ListItemIcon>
+          <ListItemText primary={`${verse.chapter}:${verse.verse}`} />
+        </ListItemButton>
+      </ListItem>
+    )
+  })
+
+  return (
+    <Box id={`verse-list-${resourceId}`} sx={{ minWidth: '360px',maxWidth: '600px', bgcolor: 'background.paper' }}>
+      <List>
+        {renderedVerseItems}
+      </List>
+    </Box>
+  )
+}
+
+const VerseSelectorPopup = ({ resourceId, versesForRef, versesAlignmentStatus, onVerseSelect, open, onClose }) => {
+  return (
+
+    <DraggableCard
+      id={`verse-selector-popup-${resourceId}`}
+      title="Select Verse to Align"
+      open={open}
+      showRawContent
+      initialPosition={{ x: 0, y: -10 }}
+      // workspaceRef={mainScreenRef}
+      onClose={onClose}
+      dimBackground={true}
+      content={
+        <VerseSelectorContent
+          resourceId={resourceId}
+          versesForRef={versesForRef}
+          versesAlignmentStatus={versesAlignmentStatus}
+          onVerseSelect={onVerseSelect}
+        />
+      }
+    />
+  )
+}
+
+export default VerseSelectorPopup

--- a/src/components/VerseSelectorPopup/index.ts
+++ b/src/components/VerseSelectorPopup/index.ts
@@ -1,0 +1,1 @@
+export { default as VerseSelectorPopup } from './VerseSelectorPopup'


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] Move the alignment icon out of scripture pane and into scripture card toolbar.
- [ ] Add ability to align a specific verse in a reference range

## Test Instructions

- [ ] Create a reference range using TC Create
  - Test in unfoldingword org - en - PHP - 1:15
  - open tcCreate - unfoldingword org - -tN- en - PHP - 1:15
  - edit the first note and change the reference to 1:14-18 and put some Greek words in the quote
  - save changes
![image](https://user-images.githubusercontent.com/118755839/233472783-ccf7bc65-af60-457f-8bb0-3b6ce76f1c7f.png)

- [x] Navigate to that reference range in this [deploy version of gateway edit](https://deploy-preview-420--gateway-edit.netlify.app/) **v2.0.0 build ad951ea**
- [x] Click on alignment in toolbar and a list of verses for your reference range should show up

![image](https://user-images.githubusercontent.com/118755839/233471570-60fd7b1b-d400-4373-bbff-bb8e84d456da.png)

- [ ] Verify that you see a list item for each verse (or verse span) in verse range

![image](https://user-images.githubusercontent.com/118755839/233471910-2f268acc-34af-4ccb-80c0-c7922582a8be.png)

- [ ]  Click on a verse and the alignment dialog should display for this verse

![image](https://user-images.githubusercontent.com/118755839/233472156-a9e0a554-0e54-48ed-a2a6-b2052b90c796.png)

- [x]  Verify that alignment dialog closes on cancel & approve


