### PR TITLE
fixed fetchBook() to be called when sha is not given

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.4.11",
+  "version": "3.4.12",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"
@@ -16,7 +16,7 @@
     "start": "styleguidist server NODE_OPTIONS=--max_old_space_size=4096",
     "build": "styleguidist build",
     "prepublishOnly": "rm -fr ./dist && babel ./src --out-dir ./dist -s inline --extensions \".ts,.tsx,.js\"",
-    "pack-next": "yarn version --prerelease && yarn && yarn run prepublishOnly && yarn pack"
+    "pack-next": "yarn version --prerelease --no-git-tag-version && yarn && yarn run prepublishOnly && yarn pack"
   },
   "peerDependencies": {
     "@material-ui/core": "4.11.0",

--- a/src/hooks/useScripture.tsx
+++ b/src/hooks/useScripture.tsx
@@ -232,11 +232,13 @@ export function useScripture({ // hook for fetching scripture
   async function fetchBook(fetchParams, ignoreSha = null) {
     try {
       const fetchLink = `${fetchParams?.resourceLink}/${fetchParams?.reference?.projectId}`
-      const shaToBeIgnored = ignoreSha && ignoreSha === resourceState?.sha // we will reload if ignoreSha given and it matches current sha
 
-      if ((fetchLink === resourceState?.resource?.resourceLink) && !shaToBeIgnored) { // see if we already fetched this
-        console.log(`useScripture.fetchBook() - Already fetching resourceLink ${resourceState?.resource?.resourceLink} and ignoreSha=${ignoreSha}`, fetchParams)
-        return
+      if (ignoreSha) {
+        const fetchedShaMatchesIgnoreSha = ignoreSha === resourceState?.sha // we will reload if ignoreSha given and it matches current sha
+        if ((fetchLink === resourceState?.resource?.resourceLink) && !fetchedShaMatchesIgnoreSha) { // see if we already fetched this
+          console.log(`useScripture.fetchBook() - Already fetching resourceLink ${resourceState?.resource?.resourceLink} and ignoreSha=${ignoreSha}`, fetchParams)
+          return
+        }
       }
 
       const _fetchCount = fetchCount + 1


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] Fixes scripture not reloading on update from master. [Issue 546](https://app.zenhub.com/workspaces/gatewayedit-5fa302df5c4ec9001f1d5d54/issues/gh/unfoldingword/gateway-edit/546)

## Test Instructions

- [ ] Make edits to a Scripture Card
- [ ] Make to the same resource on another account
- [ ] Update the scripture card changes, verifying that content reloads
