### PR TITLE
bugfix 564 / fix for 500 errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.4.14",
+  "version": "3.4.15-beta.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.4.15-beta.24",
+  "version": "3.4.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.4.15-beta.16",
+  "version": "3.4.15-beta.17",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.3.6",
+  "version": "3.3.7-0",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.4.15-beta.17",
+  "version": "3.4.15-beta.21",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.3.7-0",
+  "version": "3.3.7-1",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.4.15-beta.21",
+  "version": "3.4.15-beta.24",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -26,6 +26,7 @@ import { ScripturePane, ScriptureSelector } from '..'
 import { useScriptureSettings } from '../../hooks/useScriptureSettings'
 import {
   cleanupVerseObjects,
+  fetchBook,
   fixOccurrence,
   getBookNameFromUsfmFileName,
   getResourceLink,
@@ -172,6 +173,7 @@ export default function ScriptureCard({
     saveClicked: false,
     saveContent: null,
     saveDiffPatch: false,
+    saveFullBibleContent: null,
     selections: new Map(),
     showAlignmentPopup: false,
     startSave: false,
@@ -194,6 +196,7 @@ export default function ScriptureCard({
     saveClicked,
     saveContent,
     saveDiffPatch,
+    saveFullBibleContent,
     selections,
     showAlignmentPopup,
     startSave,
@@ -591,52 +594,93 @@ export default function ScriptureCard({
   })
 
   React.useEffect(() => { // when we get a save saveError
-    if (saveError && isSaveError) {
+    if (saveError && isSaveError && !startSave) { // if error then show after save completes, since we may retry
       console.log(`save error`, saveError)
       onResourceError && onResourceError(null, false, null, `Error saving ${languageId_}_${resourceId} ${saveError}`, true)
     }
-  }, [saveError, isSaveError])
+  }, [saveError, isSaveError, startSave])
 
   React.useEffect(() => { // when startSave goes true, save edits to user branch and then clear startSave
+    function _saveSuccesful() {
+      console.log(`saveChangesToCloud() - save scripture edits success`)
+      setCardsSaving(prevCardsSaving => prevCardsSaving.filter(cardId => cardId !== cardResourceId))
+      setState({
+        startSave: false,
+      })
+
+      const unsavedCardIndices = Object.keys(unsavedChangesList)
+
+      if (unsavedCardIndices?.length) {
+        for (const cardIndex of unsavedCardIndices) {
+          const {clearChanges} = unsavedChangesList[cardIndex]
+          clearChanges && clearChanges()
+        }
+      }
+
+      console.info('saveChangesToCloud() - Reloading resource')
+      setState({
+        startSave: false,
+        readyForFetch: true,
+        saveFullBibleContent: null,
+        saveContent: null,
+        ref: userEditBranchName,
+      })
+      delay(100).then(() => {
+        setCardsSaving(prevCardsSaving => prevCardsSaving.filter(cardId => cardId !== cardResourceId))
+        scriptureConfig?.reloadResource(sha, userEditBranchName)
+      })
+      return true
+    }
+
     const _saveEdit = async () => { // begin uploading new USFM
       console.info(`saveChangesToCloud() - Using sha: ${sha}`)
-      let saveFunction = onSaveEdit
+      let uploadFunction = onSaveEdit
       if (saveDiffPatch) {
-        saveFunction = onSaveEditPatch // if we are sending up a diffpatch, we will use this method
+        uploadFunction = onSaveEditPatch // if we are sending up a diffpatch, we will use this method
       }
-      await saveFunction(userEditBranchName).then((success) => { // push change to server
-        if (success) {
-          console.log(`saveChangesToCloud() - save scripture edits success`)
-          setCardsSaving(prevCardsSaving => prevCardsSaving.filter(cardId => cardId !== cardResourceId))
-          setState({
-            startSave: false,
-          })
+      let success = await uploadFunction(userEditBranchName)// push change to server
+      let error = success ? null : 'saving changed scripture failed'
 
-          const unsavedCardIndices = Object.keys(unsavedChangesList)
+      if (!success) {
+        console.error('saveChangesToCloud() - saving changed scripture failed, retrying')
+        await delay(100)
+        // @ts-ignore
+        const results = await fetchBook(server, httpConfig, scriptureConfig?.resource, scriptureConfig?.reference)
+        error = results?.error
+        let _saveContent = saveContent
+        let fileSha = null
+        const savedBibleUsfm = results?.bibleUsfm
+        const editedBibleUsfm = saveFullBibleContent?.new
+        let upToDate = savedBibleUsfm === editedBibleUsfm // check if changed
 
-          if (unsavedCardIndices?.length) {
-            for (const cardIndex of unsavedCardIndices) {
-              const { clearChanges } = unsavedChangesList[cardIndex]
-              clearChanges && clearChanges()
+        if (!error) {
+          if (upToDate) {
+            success = true
+          } else {
+            if (saveDiffPatch) {
+              // regenerate the patch against the latest content
+              const diffPatch = getPatch(saveFullBibleContent?.filename, savedBibleUsfm, editedBibleUsfm, false)
+              _saveContent = diffPatch
+              fileSha = results?.sha
+            }
+
+            await delay(100)
+            success = await uploadFunction(userEditBranchName, _saveContent, fileSha) // push change to server
+            if (!success) {
+              error = 'saving changed scripture failed on second attempt'
             }
           }
-
-          console.info('saveChangesToCloud() - Reloading resource')
-          setState({
-            startSave: false,
-            readyForFetch: true,
-            ref: userEditBranchName,
-          })
-          delay(100).then(() => {
-            setCardsSaving(prevCardsSaving => prevCardsSaving.filter(cardId => cardId !== cardResourceId))
-            scriptureConfig?.reloadResource(sha, userEditBranchName)
-          })
-        } else {
-          console.error('saveChangesToCloud() - saving changed scripture failed')
-          setCardsSaving(prevCardsSaving => prevCardsSaving.filter(cardId => cardId !== cardResourceId))
-          setState({ startSave: false })
         }
-      })
+      }
+
+      if (!error && success) { // if no error message and save was a success
+        return _saveSuccesful() // nothing to do
+      }
+
+      console.error(`saveChangesToCloud() - ${error || 'unknown save error'}`)
+      setCardsSaving(prevCardsSaving => prevCardsSaving.filter(cardId => cardId !== cardResourceId))
+      setState({startSave: false})
+      return false
     }
 
     if (startSave) {
@@ -734,11 +778,11 @@ export default function ScriptureCard({
         const unsavedCardIndices = Object.keys(unsavedChangesList)
 
         if (unsavedCardIndices?.length) {
-          let bibleUsfm_ = getCurrentBook(scriptureConfig, bookId) // get original USFM
-          let bibleUsfm = bibleUsfm_ // make a copy to edit
+          let bibleUsfmInitial = getCurrentBook(scriptureConfig, bookId) // get original USFM
+          let bibleUsfmNew = bibleUsfmInitial // make a copy to edit
           let mergeFail = false
 
-          if (bibleUsfm_) {
+          if (bibleUsfmInitial) {
             let cardNum = 0
 
             for (const cardIndex of unsavedCardIndices) {
@@ -752,12 +796,12 @@ export default function ScriptureCard({
                   updatedVerseObjects,
                 } = getChanges(state)
 
-                if (updatedVerseObjects && bibleUsfm) { // just replace verse
-                  newUsfm = mergeVerseObjectsIntoBibleUsfm(bibleUsfm, ref, updatedVerseObjects, cardNum)
+                if (updatedVerseObjects && bibleUsfmNew) { // just replace verse
+                  newUsfm = mergeVerseObjectsIntoBibleUsfm(bibleUsfmNew, ref, updatedVerseObjects, cardNum)
                 }
 
                 if (newUsfm) {
-                  bibleUsfm = newUsfm
+                  bibleUsfmNew = newUsfm
                 } else {
                   mergeFail = true
                   break
@@ -767,6 +811,8 @@ export default function ScriptureCard({
           }
 
           let saveDiffPatch = false // if true then we will send up a diffpatch instead of the whole book
+          let _saveFullBibleContent = null
+          let _saveContent = bibleUsfmNew
 
           if (mergeFail) { // if we failed to merge, fallback to brute force verse objects to USFM
             console.log(`saveChangesToCloud(${cardNum}) - verse not found, falling back to inserting verse object`)
@@ -800,28 +846,34 @@ export default function ScriptureCard({
               }
             }
 
-            bibleUsfm = usfmjs.toUSFM(newBookJson, { forcedNewLines: true })
+            _saveContent = usfmjs.toUSFM(newBookJson, { forcedNewLines: true })
           } else { // if only changed a few verses, we will just make a diffpatch instead of sending the whole book
             const filename = scriptureConfig?.resourceState?.resource?.name // Like "57-TIT.usfm"
-            if (filename && bibleUsfm && bibleUsfm_) { // make sure we have everything needed to make a patch
-              if (bibleUsfm_ === bibleUsfm) { // if no data change, then skip save because DCS crashes on an empty patch
+            if (filename && bibleUsfmNew && bibleUsfmInitial) { // make sure we have everything needed to make a patch
+              if (bibleUsfmInitial === bibleUsfmNew) { // if no data change, then skip save because DCS crashes on an empty patch
                 console.warn(`saveChangesToCloud() - there is nothing to save, skipping`)
                 setState({ saveClicked: false })
                 return
               }
-              const diffPatch = getPatch(filename, bibleUsfm_, bibleUsfm, false)
-              bibleUsfm_ = diffPatch // replace whole book with patch data (much shorter)
+              const diffPatch = getPatch(filename, bibleUsfmInitial, bibleUsfmNew, false)
               saveDiffPatch = true
+              _saveContent = diffPatch // replace whole book content with just patch data (much faster uploads)
+              _saveFullBibleContent = {  // keep track of patch data in case we need to retry save
+                filename,
+                initial: bibleUsfmInitial,
+                new: bibleUsfmNew,
+              }
             }
           }
 
-          if (bibleUsfm) {
-            console.log(`saveChangesToCloud() - saving new USFM: ${bibleUsfm.substring(0, 100)}...`)
+          if (bibleUsfmNew) {
+            console.log(`saveChangesToCloud() - saving new USFM: ${bibleUsfmNew.substring(0, 100)}...`)
             setCardsSaving(prevCardsSaving => [...prevCardsSaving, cardResourceId])
             setState({
-              saveContent: bibleUsfm_,
+              saveContent: _saveContent,
               saveClicked: false,
               saveDiffPatch,
+              saveFullBibleContent: _saveFullBibleContent,
               startSave: true,
             })
           } else {

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -26,7 +26,7 @@ import { ScripturePane, ScriptureSelector } from '..'
 import { useScriptureSettings } from '../../hooks/useScriptureSettings'
 import {
   cleanupVerseObjects,
-  fetchBook,
+  fetchBibleBook,
   fixOccurrence,
   getBookNameFromUsfmFileName,
   getResourceLink,
@@ -645,7 +645,7 @@ export default function ScriptureCard({
         console.error('saveChangesToCloud() - saving changed scripture failed, retrying')
         await delay(100)
         // @ts-ignore
-        const results = await fetchBook(server, httpConfig, scriptureConfig?.resource, scriptureConfig?.reference)
+        const results = await fetchBibleBook(server, httpConfig, scriptureConfig?.resource, scriptureConfig?.reference)
         error = results?.error
         let _saveContent = saveContent
         let fileSha = null

--- a/src/hooks/useScripture.tsx
+++ b/src/hooks/useScripture.tsx
@@ -4,7 +4,6 @@ import {
   useState,
 } from 'react'
 import { core } from 'scripture-resources-rcl'
-import usfmjs from 'usfm-js'
 import {
   CONTENT_NOT_FOUND_ERROR,
   ERROR_STATE,
@@ -18,7 +17,11 @@ import useDeepCompareEffect from 'use-deep-compare-effect'
 import { getVerses } from 'bible-reference-range'
 import { isEqual } from '@react-hookz/deep-equal'
 import { AlignmentHelpers, UsfmFileConversionHelpers } from 'word-aligner-rcl'
-import { delay, verseObjectsHaveWords } from '../utils'
+import {
+  delay,
+  fetchBibleBookCore,
+  verseObjectsHaveWords,
+} from '../utils'
 import {
   cleanupVerseObjects,
   getBookNameFromUsfmFileName,
@@ -26,6 +29,7 @@ import {
   parseResourceLink,
 } from '../utils/ScriptureSettings'
 import {
+  BookFetchParams,
   BookObjectsType,
   ScriptureResource,
   ScriptureReference,
@@ -121,11 +125,7 @@ export function useScripture({ // hook for fetching scripture
     fetchCount: number,
     fetched: boolean,
     fetchedBook: string,
-    fetchParams: {
-      config: {},
-      reference: {},
-      resourceLink: string,
-    },
+    fetchParams: BookFetchParams|null,
     ignoreSha: string|null,
     initialized: boolean,
     resourceState: {
@@ -160,11 +160,7 @@ export function useScripture({ // hook for fetching scripture
     fetchCount: 0,
     fetched: false,
     fetchedBook: '',
-    fetchParams: {
-      config: {},
-      reference: {},
-      resourceLink: '',
-    },
+    fetchParams: null,
     ignoreSha: null,
     initialized: false,
     resourceState: {
@@ -189,7 +185,7 @@ export function useScripture({ // hook for fetching scripture
     ref = null,
   } = resource_ || {}
 
-  const { projectId: bookId} = reference || {}
+  const { projectId: bookId } = reference || {}
 
   const _state: StateTypes = state // Tricky: work-around for bug that standard typescript type casting does not work in .tsx files
   const {
@@ -273,7 +269,7 @@ export function useScripture({ // hook for fetching scripture
    * @param {object} fetchParams
    * @param {string} ignoreSha - optional previous sha - ignore responses that came back for this previous book commit
    */
-  async function fetchBook(fetchParams, ignoreSha = null) {
+  async function fetchBook(fetchParams: BookFetchParams, ignoreSha = null) {
     try {
       const fetchLink = `${fetchParams?.resourceLink}/${fetchParams?.reference?.projectId}`
 
@@ -294,58 +290,28 @@ export function useScripture({ // hook for fetching scripture
         resourceState: { loadingResource: true },
       })
 
-      // fetch manifest data
-      await delay(100)
-      const _resource = await core.resourceFromResourceLink(fetchParams)
+      const response = await fetchBibleBookCore(fetchParams)
 
-      if (!_resource?.manifest || !_resource?.project?.file) {
-        const errorMsg = _resource?.manifest ? 'parsing resource manifest' : 'loading resource manifest'
-        console.warn(`useScripture.fetchBook() - error ${errorMsg}`, fetchParams )
+      if (!response || response?.error) {
+        console.log(`useScripture.warn() -Error FETCHING bible ${resource_?.projectId}`, response)
         setState({
           resourceState: {
             loadingResource: false,
-            resource: _resource,
+            resource: response,
           },
         })
         return
       }
 
-      console.log(`useScripture.fetchBook() - LOADED bible manifest, fetching book ${resource_?.projectId} resourceLink is now ${fetchParams?.resourceLink} and resourceLink_=${fetchParams?.resourceLink_}`, fetchParams)
-      await delay(100)
-      const response = await _resource?.project?.file()
-      // parse book usfm
-      const bibleUsfm = response && core.getResponseData(response)
-      await delay(100)
-      const bookObjects = bibleUsfm && usfmjs.toJSON(bibleUsfm) // convert to bible objects
-
-      if (!bookObjects) {
-        const errorMsg = bibleUsfm ? 'fetching book of the bible' : 'parsing book of the bible'
-        console.warn(`useScripture.fetchBook() - error ${errorMsg}`, fetchParams )
-        setState({
-          resourceState: {
-            loadingResource: false,
-            resource: _resource,
-          },
-        })
-        return
-      }
-
-      const { name, sha, url } = response?.data || {}
-
-      console.log(`useScripture.fetchBook() - LOADED bible book ${resource_?.projectId} resourceLink is now ${fetchParams?.resourceLink} and resourceLink_=${fetchParams?.resourceLink_}`, fetchParams)
+      console.log(`useScripture.fetchBook() - LOADED bible book ${resource_?.projectId} resourceLink is now ${fetchParams?.resourceLink}}`, fetchParams)
       setState(
         {
           resourceState: {
             loadingResource: false,
             fetchedResources: {
-              ..._resource,
-              bibleUsfm,
-              bookObjects,
+              ...response,
               fetchCount: _fetchCount,
-              name,
               reference: fetchParams?.reference,
-              sha,
-              url,
             },
           },
         },
@@ -539,7 +505,7 @@ export function useScripture({ // hook for fetching scripture
    */
   function reloadResource(ignoreSha = null, ref = null) {
     console.log(`useScripture.reloadResource() ignoreSha: ${ignoreSha}` )
-    const _fetchParams = { ...fetchParams }
+    const _fetchParams: BookFetchParams = { ...fetchParams }
 
     if (ref && fetchParams?.resourceLink) {
       const {

--- a/src/hooks/useScripture.tsx
+++ b/src/hooks/useScripture.tsx
@@ -297,7 +297,7 @@ export function useScripture({ // hook for fetching scripture
         setState({
           resourceState: {
             loadingResource: false,
-            resource: response,
+            response,
           },
         })
         return

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -83,3 +83,13 @@ export interface ScriptureConfig {
   fetchResponse: { data: {sha: string} }
 }
 
+export interface BookFetchParams {
+  config: {} | ServerConfig;
+  // TODO: document all the formats supported in
+  // see parseResourceLink in scripture-resources-rcl for other formats supported,
+  // but most common is <owner>/<language>/<resourceId>/<branch>/<bookId> (e.g. ru_gl/ru/rlob/master/tit)
+  resourceLink?: string;
+  // parameters used to generate resourceLink if it's not present
+  resource?: ScriptureResource;
+  reference?: ScriptureReference;
+}

--- a/src/utils/ScriptureSettings.ts
+++ b/src/utils/ScriptureSettings.ts
@@ -478,11 +478,11 @@ export async function fetchBibleBookCore(fetchParams: BookFetchParams) {
 
     if (!resource?.manifest || !resource?.project?.file) {
       const errorMsg = resource?.manifest ? 'parsing resource manifest' : 'loading resource manifest'
-      console.warn(`fetchBook() - error ${errorMsg}`, fetchParams )
+      console.warn(`fetchBibleBookCore() - error ${errorMsg}`, fetchParams )
       return { error: errorMsg, resourceError: true }
     }
 
-    console.log(`fetchBook() - LOADED bible manifest, fetching book  ${fetchParams?.resourceLink}`, fetchParams)
+    console.log(`fetchBibleBookCore() - LOADED bible manifest, fetching book  ${fetchParams?.resourceLink}`, fetchParams)
     await delay(100)
     const response = await resource?.project?.file()
     // parse book usfm
@@ -492,7 +492,7 @@ export async function fetchBibleBookCore(fetchParams: BookFetchParams) {
 
     if (!bookObjects) {
       const errorMsg = bibleUsfm ? 'fetching book of the bible' : 'parsing book of the bible'
-      console.warn(`fetchBook() - error ${errorMsg}`, fetchParams )
+      console.warn(`fetchBibleBookCore() - error ${errorMsg}`, fetchParams )
       return { error: errorMsg }
     }
 
@@ -502,7 +502,7 @@ export async function fetchBibleBookCore(fetchParams: BookFetchParams) {
       url,
     } = response?.data || {}
 
-    console.log(`fetchBook() - LOADED bible book,  ${fetchParams?.resourceLink}`, fetchParams)
+    console.log(`fetchBibleBookCore() - LOADED bible book,  ${fetchParams?.resourceLink}`, fetchParams)
     return {
       ...resource,
       bibleUsfm,
@@ -514,7 +514,7 @@ export async function fetchBibleBookCore(fetchParams: BookFetchParams) {
     }
   } catch (e) {
     const errorMsg = 'hard error loading resource'
-    console.error(`fetchBook() - ${errorMsg}`, fetchParams, e )
+    console.error(`fetchBibleBookCore() - ${errorMsg}`, fetchParams, e )
     return { error: errorMsg }
   }
 }

--- a/src/utils/files.ts
+++ b/src/utils/files.ts
@@ -25,7 +25,7 @@ export function getPatch(fileName, originalFileContents, editedFileContents, jso
   let diffResult = createPatch(fileName, originalFileContents, editedFileContents)
 
   if (jsonEscape) {
-    diffResult = escapeJsonStringChars(diffResult);
+    diffResult = escapeJsonStringChars(diffResult)
   }
   return diffResult
 }


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] separated the fetchBook functionality from useScripture into utility function
- [ ] on save error we will now:
  - [ ] do a fetch of the repo to get the latest content and file sha
  - [ ] if content is different than what was saved, it will retry the save with the current file sha.

## Test Instructions

- [ ] test with https://deploy-preview-583--gateway-edit.netlify.app/
- [ ] should not see any problems saving scripture, particularly no 500 errors.  401 authentication errors are in another issue.

