### PR TITLE
qaFail 602 / Save button is enabled when edit box is clicked

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.4.15",
+  "version": "3.4.16",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.3.6",
+  "version": "3.3.7-0",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.3.7-0",
+  "version": "3.3.7-1",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/hooks/useScriptureAlignmentEdit.tsx
+++ b/src/hooks/useScriptureAlignmentEdit.tsx
@@ -506,7 +506,7 @@ export function useScriptureAlignmentEdit({
     if (enableEdit) {
       if (editing_ !== editing) {
         _newVerseText = _newVerseText || initialVerseText
-        let _updatedVerseObjects = updatedVerseObjects || currentVerseObjects
+        let _updatedVerseObjects = null
         const verseTextChanged = _newVerseText !== initialVerseText
         const newState = {
           editing: editing_,
@@ -514,20 +514,13 @@ export function useScriptureAlignmentEdit({
           verseTextChanged,
         }
 
-        if (editing_ ) { // by default do migration of alignments to match latest original language
-          _updatedVerseObjects = migrateAlignments('setEditing()', _updatedVerseObjects)
-        }
-
-        if (!verseTextChanged) {
-          // fallback to make sure text from verseObjects matches current text
-          const verseText = UsfmFileConversionHelpers.getUsfmForVerseContent({ verseObjects: currentVerseObjects } )
-
-          if (hasTextChangedSignificantly(verseText, _newVerseText)) {
-            // apply alignment to current text
-            const { targetVerseObjects } = AlignmentHelpers.updateAlignmentsToTargetVerse(currentVerseObjects, _newVerseText)
-            _updatedVerseObjects = targetVerseObjects // update verseObjects to match current text
-            newState['updatedVerseObjects'] = _updatedVerseObjects
-          }
+        if (!editing_ && verseTextChanged) { // if done editing and verse has changed, update the verse objects
+          // do migration of alignments to match latest original language
+          _updatedVerseObjects = migrateAlignments('setEditing()', updatedVerseObjects || currentVerseObjects)
+          // apply alignments from updated verseObjects to edited verse text
+          const { targetVerseObjects } = AlignmentHelpers.updateAlignmentsToTargetVerse(_updatedVerseObjects, _newVerseText)
+          _updatedVerseObjects = targetVerseObjects // update verseObjects to match current text
+          newState['updatedVerseObjects'] = _updatedVerseObjects
         }
 
         setState(newState)


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] simplified setEdit() logic to only apply changes on edit completion and then update alignments in verseObject

## Test Instructions

- [ ] test with https://deploy-preview-608--gateway-edit.netlify.app/
