### PR TITLE
Bugfix 526 / fix slow text edit behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.4.17",
+  "version": "3.4.20-beta.15",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "single-scripture-rcl",
   "description": "A React Component Library for Rendering a Single Scripture Resource.",
-  "version": "3.4.20-beta.15",
+  "version": "3.4.18",
   "repository": {
     "type": "git",
     "url": "https://github.com/unfoldingWord/single-scripture-rcl.git"

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -450,7 +450,7 @@ export default function ScriptureCard({
    * @param {boolean} editing - true when editing
    */
   function setEditVerse(verseRef, editing) {
-    if (editing && (verseRef !== editVerse)) { // if we need to set flag that we are editing this verse
+    if (editing && (verseRef !== editVerse)) { // check if we need to set flag that we are editing this verse
       setState({ editVerse: verseRef })
     } else if (!editing && (verseRef === editVerse)) { // clear edit flag if it is for current edit verse
       setState({ editVerse: null })
@@ -1140,7 +1140,7 @@ export default function ScriptureCard({
   const handleAlignButtonClick = () => {
     if (versesForRef?.length > 1) { // if there are multiple verses shown in card, need to prompt user for which verse to align
       setState({ showAlignmentPopup: true })
-    } else if (versesForRef?.length === 1) { // if only one verse is shown, then edit that verse
+    } else if (versesForRef?.length === 1) { // if only one verse is shown on card, then edit that verse
       setState({ verseSelectedForAlignment: versesForRef[0] })
     }
   }

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -457,7 +457,7 @@ export default function ScriptureCard({
     }
   }
 
-  const disableChangeButtons = editVerse // we don't want to allow clicking on change buttons while editing
+  const disableChangeButtons = !!editVerse // we don't want to allow clicking on change buttons while editing
 
   function onMenuClose() {
     // console.log(`onMenuClose()`)

--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -172,6 +172,7 @@ export default function ScriptureCard({
     checkForEditBranch: 0,
     currentReference: null,
     editBranchReady: false,
+    editVerse: null,
     haveUnsavedChanges: false,
     lastSelectedQuote: null,
     readyForFetch: false,
@@ -196,6 +197,7 @@ export default function ScriptureCard({
     checkForEditBranch,
     currentReference,
     editBranchReady,
+    editVerse, // keep track of verse being editted
     haveUnsavedChanges,
     lastSelectedQuote,
     readyForFetch,
@@ -394,7 +396,7 @@ export default function ScriptureCard({
   React.useEffect(() => {
     if (!isEqual(reference, currentReference)) {
       // console.log(`ScriptureCard reference changed`, reference)
-      setState({ currentReference: reference })
+      setState({ currentReference: reference, editVerse: null })
     }
   }, [reference])
 
@@ -441,6 +443,21 @@ export default function ScriptureCard({
 
     return <ScriptureSelector {...scriptureSelectionConfig} style={style} errorMessage={urlError} />
   }
+
+  /**
+   * set edit state for specific verse
+   * @param {string} verseRef - reference of verse being edited or finished edit
+   * @param {boolean} editing - true when editing
+   */
+  function setEditVerse(verseRef, editing) {
+    if (editing && (verseRef !== editVerse)) { // if we need to set flag that we are editing this verse
+      setState({ editVerse: verseRef })
+    } else if (!editing && (verseRef === editVerse)) { // clear edit flag if it is for current edit verse
+      setState({ editVerse: null })
+    }
+  }
+
+  const disableChangeButtons = editVerse // we don't want to allow clicking on change buttons while editing
 
   function onMenuClose() {
     // console.log(`onMenuClose()`)
@@ -1111,6 +1128,7 @@ export default function ScriptureCard({
         saving={startSave}
         // @ts-ignore
         scriptureAlignmentEditConfig={_scriptureAlignmentEditConfig}
+        setEditVerse={setEditVerse}
         setWordAlignerStatus={setWordAlignerStatus}
         server={server}
         translate={translate}
@@ -1120,9 +1138,9 @@ export default function ScriptureCard({
   })
 
   const handleAlignButtonClick = () => {
-    if (versesForRef?.length > 1) {
+    if (versesForRef?.length > 1) { // if there are multiple verses shown in card, need to prompt user for which verse to align
       setState({ showAlignmentPopup: true })
-    } else if (versesForRef?.length === 1) {
+    } else if (versesForRef?.length === 1) { // if only one verse is shown, then edit that verse
       setState({ verseSelectedForAlignment: versesForRef[0] })
     }
   }
@@ -1144,7 +1162,8 @@ export default function ScriptureCard({
       alignIcon = <RxLink2 id={`valid_icon_${resourceId}`} color='#BBB' />
       alignButtonText = 'Alignment is Valid'
     } else {
-      alignIcon = <RxLinkBreak2 id={`invalid_alignment_icon_${resourceId}`} color='#000' />
+      const color = disableChangeButtons ? '#BBB' : '#000' // gray out button if disabled
+      alignIcon = <RxLinkBreak2 id={`invalid_alignment_icon_${resourceId}`} color={color} />
       alignButtonText = 'Alignment is Invalid'
     }
 
@@ -1153,7 +1172,7 @@ export default function ScriptureCard({
         <IconButton
           id={`alignment_icon_${resourceId}`}
           key='checking-button'
-          onClick={handleAlignButtonClick}
+          onClick={disableChangeButtons ? null : handleAlignButtonClick}
           title={alignButtonText}
           aria-label={alignButtonText}
           style={{ cursor: 'pointer' }}
@@ -1207,7 +1226,7 @@ export default function ScriptureCard({
         onMenuClose={onMenuClose}
         onMinimize={onMinimize ? () => onMinimize(id, scriptureTitle) : null}
         editable={enableEdit || enableAlignment}
-        saved={startSave || !haveUnsavedChanges}
+        saved={disableChangeButtons || startSave || !haveUnsavedChanges} // gray out save button if disabled, if saving, or if no unsaved changes
         onSaveEdit={() => setState({ saveClicked: true })}
         onRenderToolbar={onRenderToolbar}
       >

--- a/src/components/ScripturePane/ScripturePane.tsx
+++ b/src/components/ScripturePane/ScripturePane.tsx
@@ -183,27 +183,15 @@ function ScripturePane({
   } = _scriptureAlignmentEdit
 
   React.useEffect(() => {
-    if (isVerseSelectedForAlignment && !alignerData && !doingAlignment) {
-      if (!editing && !processingEdit) {
+    if (isVerseSelectedForAlignment && !alignerData && !doingAlignment) { // check if edit for this verse is selected and not already doing alignment
+      if (!editing && !processingEdit) { // make sure edit completed
         console.log(`ScripturePane - verse selected for alignment`, reference)
         handleAlignmentClick()
       } else {
-        console.log(`ScripturePane - verse not ready for alignment`, {editing, processingEdit})
+        console.log(`ScripturePane - still editing verse, not ready for alignment`, {editing, processingEdit})
       }
     }
   }, [isVerseSelectedForAlignment, alignerData, doingAlignment, editing, processingEdit])
-
-  // const verseChanged = React.useMemo(() => {
-  //   return (newVerseText !== newText)
-  // }, [newVerseText, newText])
-  //
-  // React.useEffect(() => {
-  //   if (newVerseText !== newText) {
-  //     console.log(`ScripturePane - new verse text diverged`, { newVerseText, newText })
-  //   } else {
-  //     console.log(`ScripturePane - new verse text converged`, { newVerseText })
-  //   }
-  // }, [verseChanged])
 
   React.useEffect(() => {
     updateVersesAlignmentStatus && updateVersesAlignmentStatus(reference, aligned)
@@ -245,14 +233,14 @@ function ScripturePane({
   function onBlur(event: React.ChangeEvent<HTMLTextAreaElement>) {
     const newVerseText = event?.target?.value // get new text
     setState({ newText: newVerseText, processingEdit: true })
-    delay(500).then(() => { // allow state to update
+    delay(500).then(() => { // allow state to update before processing new text
       setEditing(false, newVerseText).then(() => { // process the latest edit
         setState({processingEdit: false})
       })
     })
   }
 
-  React.useEffect(() => { // monitor for edit state changes and call back with edit status to scripture card
+  React.useEffect(() => { // monitor for edit state changes and call back to scripture card with edit status
     const _editing = editing || processingEdit
     const verseRef = `${reference.chapter}:${reference.verse}`
     setEditVerse && setEditVerse(verseRef, _editing)
@@ -266,7 +254,7 @@ function ScripturePane({
    * @param {boolean} editing - if true show edit mode
    * @param {boolean} enableEdit - if true then edit is enabled
    * @param {boolean} noWords - if true then there are no displayable words
-   * @param {boolean} processingEdit - true if edit is being processed
+   * @param {boolean} processingEdit - if true then edit is being processed
    */
   function verseContent(editing, enableEdit, noWords, processingEdit) {
     if (processingEdit) { // put up spinner while processing the edit

--- a/src/components/ScripturePane/ScripturePane.tsx
+++ b/src/components/ScripturePane/ScripturePane.tsx
@@ -182,9 +182,9 @@ function ScripturePane({
     },
   } = _scriptureAlignmentEdit
 
-  React.useEffect(() => {
+  React.useEffect(() => { // monitor if we need to start alignment
     if (isVerseSelectedForAlignment && !alignerData && !doingAlignment) { // check if edit for this verse is selected and not already doing alignment
-      if (!editing && !processingEdit) { // make sure edit completed
+      if (!editing && !processingEdit) { // make sure not still editing or processing edit
         console.log(`ScripturePane - verse selected for alignment`, reference)
         handleAlignmentClick()
       } else {
@@ -230,12 +230,16 @@ function ScripturePane({
     setState({ newText: null })
   }, [{ reference, initialVerseObjects }])
 
+  /**
+   * when focus is changed from text editing, get final text and do processing of final text
+   * @param {React.ChangeEvent<HTMLTextAreaElement>} event - DOM event info
+   */
   function onBlur(event: React.ChangeEvent<HTMLTextAreaElement>) {
     const newVerseText = event?.target?.value // get new text
-    setState({ newText: newVerseText, processingEdit: true })
+    setState({ newText: newVerseText, processingEdit: true }) // show spinner while processing edit text
     delay(500).then(() => { // allow state to update before processing new text
-      setEditing(false, newVerseText).then(() => { // process the latest edit
-        setState({processingEdit: false})
+      setEditing(false, newVerseText).then(() => { // process the latest edit text
+        setState({processingEdit: false}) // now done, remove spinner
       })
     })
   }

--- a/src/components/ScripturePane/ScripturePane.tsx
+++ b/src/components/ScripturePane/ScripturePane.tsx
@@ -245,15 +245,14 @@ function ScripturePane({
   function onBlur(event: React.ChangeEvent<HTMLTextAreaElement>) {
     const newVerseText = event?.target?.value // get new text
     setState({ newText: newVerseText, processingEdit: true })
-    delay(500).then(() => {
-      setEditing(false, newVerseText) // process the latest edit after states update
+    delay(500).then(() => { // allow state to update
+      setEditing(false, newVerseText).then(() => { // process the latest edit
+        setState({processingEdit: false})
+      })
     })
   }
 
   React.useEffect(() => { // monitor for edit state changes and call back with edit status to scripture card
-    if (!editing && processingEdit) {
-      setState({ processingEdit: false })
-    }
     const _editing = editing || processingEdit
     const verseRef = `${reference.chapter}:${reference.verse}`
     setEditVerse && setEditVerse(verseRef, _editing)

--- a/src/components/ScripturePane/ScripturePane.tsx
+++ b/src/components/ScripturePane/ScripturePane.tsx
@@ -250,7 +250,7 @@ function ScripturePane({
     })
   }
 
-  React.useEffect(() => { // monitor for edit state chagnes and call back status to scripture card
+  React.useEffect(() => { // monitor for edit state changes and call back with edit status to scripture card
     if (!editing && processingEdit) {
       setState({ processingEdit: false })
     }
@@ -267,7 +267,7 @@ function ScripturePane({
    * @param {boolean} editing - if true show edit mode
    * @param {boolean} enableEdit - if true then edit is enabled
    * @param {boolean} noWords - if true then there are no displayable words
-   * @param {boolean} processingEdit - true if edit is being processes
+   * @param {boolean} processingEdit - true if edit is being processed
    */
   function verseContent(editing, enableEdit, noWords, processingEdit) {
     if (processingEdit) { // put up spinner while processing the edit

--- a/src/hooks/useScriptureAlignmentEdit.tsx
+++ b/src/hooks/useScriptureAlignmentEdit.tsx
@@ -522,7 +522,7 @@ export function useScriptureAlignmentEdit({
             _updatedVerseObjects = migrateAlignments('setEditing()', _updatedVerseObjects)
           }
 
-          // apply alignments from updated verseObjects to edited verse text
+          // apply alignments from updated verseObjects to edited verse text and generate new verse objects
           const { targetVerseObjects } = AlignmentHelpers.updateAlignmentsToTargetVerse(_updatedVerseObjects, _newVerseText)
           _updatedVerseObjects = targetVerseObjects // update verseObjects to match current text
           newState['updatedVerseObjects'] = _updatedVerseObjects

--- a/src/hooks/useScriptureAlignmentEdit.tsx
+++ b/src/hooks/useScriptureAlignmentEdit.tsx
@@ -507,17 +507,17 @@ export function useScriptureAlignmentEdit({
         _newVerseText = _newVerseText || initialVerseText
         let _updatedVerseObjects = null
         const verseTextChangedFromLastEdit = _newVerseText !== newVerseText
-        const verseTextChanged = _newVerseText !== initialVerseText
+        const verseTextChangedFromOrig = _newVerseText !== initialVerseText
         const newState = {
           editing: editing_,
           newVerseText: _newVerseText,
-          verseTextChanged,
+          verseTextChanged: verseTextChangedFromOrig,
         }
 
         if (!editing_ && verseTextChangedFromLastEdit) { // if done editing and verse has changed, update the verse objects
           _updatedVerseObjects = updatedVerseObjects || currentVerseObjects
 
-          if (verseTextChanged) { // if verse has changed from initial, update the verse objects
+          if (verseTextChangedFromOrig) { // if verse has changed from initial, update the verse objects
             // do migration of alignments to match latest original language
             _updatedVerseObjects = migrateAlignments('setEditing()', _updatedVerseObjects)
           }
@@ -530,7 +530,7 @@ export function useScriptureAlignmentEdit({
 
         setState(newState)
         const _alignmentsChanged = (_updatedVerseObjects && !isEqual(initialVerseObjects, _updatedVerseObjects))
-        callSetSavedState(verseTextChanged || _alignmentsChanged, newState )
+        callSetSavedState(verseTextChangedFromOrig || _alignmentsChanged, newState )
       }
     }
   }

--- a/src/hooks/useScriptureAlignmentEdit.tsx
+++ b/src/hooks/useScriptureAlignmentEdit.tsx
@@ -507,17 +507,17 @@ export function useScriptureAlignmentEdit({
         _newVerseText = _newVerseText || initialVerseText
         let _updatedVerseObjects = null
         const verseTextChangedFromLastEdit = _newVerseText !== newVerseText
-        const verseTextChangedFromOrig = _newVerseText !== initialVerseText
+        const verseTextChangedFromInitial = _newVerseText !== initialVerseText
         const newState = {
           editing: editing_,
           newVerseText: _newVerseText,
-          verseTextChanged: verseTextChangedFromOrig,
+          verseTextChanged: verseTextChangedFromInitial,
         }
 
         if (!editing_ && verseTextChangedFromLastEdit) { // if done editing and verse has changed, update the verse objects
           _updatedVerseObjects = updatedVerseObjects || currentVerseObjects
 
-          if (verseTextChangedFromOrig) { // if verse has changed from initial, migrate alignments in the verse objects
+          if (verseTextChangedFromInitial) { // if verse has changed from initial, migrate alignments in the verse objects
             // do migration of alignments to match latest original language
             _updatedVerseObjects = migrateAlignments('setEditing()', _updatedVerseObjects)
           }
@@ -530,7 +530,7 @@ export function useScriptureAlignmentEdit({
 
         setState(newState)
         const _alignmentsChanged = (_updatedVerseObjects && !isEqual(initialVerseObjects, _updatedVerseObjects))
-        callSetSavedState(verseTextChangedFromOrig || _alignmentsChanged, newState )
+        callSetSavedState(verseTextChangedFromInitial || _alignmentsChanged, newState )
       }
     }
   }

--- a/src/hooks/useScriptureAlignmentEdit.tsx
+++ b/src/hooks/useScriptureAlignmentEdit.tsx
@@ -517,7 +517,7 @@ export function useScriptureAlignmentEdit({
         if (!editing_ && verseTextChangedFromLastEdit) { // if done editing and verse has changed, update the verse objects
           _updatedVerseObjects = updatedVerseObjects || currentVerseObjects
 
-          if (verseTextChangedFromOrig) { // if verse has changed from initial, update the verse objects
+          if (verseTextChangedFromOrig) { // if verse has changed from initial, migrate alignments in the verse objects
             // do migration of alignments to match latest original language
             _updatedVerseObjects = migrateAlignments('setEditing()', _updatedVerseObjects)
           }

--- a/src/hooks/useScriptureAlignmentEdit.tsx
+++ b/src/hooks/useScriptureAlignmentEdit.tsx
@@ -514,20 +514,18 @@ export function useScriptureAlignmentEdit({
           verseTextChanged,
         }
 
-        if (!editing_) { // if done editing and verse has changed, update the verse objects
+        if (!editing_ && verseTextChangedFromLastEdit) { // if done editing and verse has changed, update the verse objects
+          _updatedVerseObjects = updatedVerseObjects || currentVerseObjects
+
           if (verseTextChanged) { // if verse has changed from initial, update the verse objects
             // do migration of alignments to match latest original language
-            _updatedVerseObjects = migrateAlignments('setEditing()', updatedVerseObjects || currentVerseObjects)
-            // apply alignments from updated verseObjects to edited verse text
-            const { targetVerseObjects } = AlignmentHelpers.updateAlignmentsToTargetVerse(_updatedVerseObjects, _newVerseText)
-            _updatedVerseObjects = targetVerseObjects // update verseObjects to match current text
-            newState['updatedVerseObjects'] = _updatedVerseObjects
-          } else if (verseTextChangedFromLastEdit) { // if verse changed from last time (went back to initial text), update the verse objects without migration
-            _updatedVerseObjects = updatedVerseObjects || currentVerseObjects
-            const { targetVerseObjects } = AlignmentHelpers.updateAlignmentsToTargetVerse(_updatedVerseObjects, _newVerseText)
-            _updatedVerseObjects = targetVerseObjects // update verseObjects to match current text
-            newState['updatedVerseObjects'] = _updatedVerseObjects
+            _updatedVerseObjects = migrateAlignments('setEditing()', _updatedVerseObjects)
           }
+
+          // apply alignments from updated verseObjects to edited verse text
+          const { targetVerseObjects } = AlignmentHelpers.updateAlignmentsToTargetVerse(_updatedVerseObjects, _newVerseText)
+          _updatedVerseObjects = targetVerseObjects // update verseObjects to match current text
+          newState['updatedVerseObjects'] = _updatedVerseObjects
         }
 
         setState(newState)

--- a/src/hooks/useScriptureAlignmentEdit.tsx
+++ b/src/hooks/useScriptureAlignmentEdit.tsx
@@ -506,6 +506,7 @@ export function useScriptureAlignmentEdit({
       if (editing_ !== editing) {
         _newVerseText = _newVerseText || initialVerseText
         let _updatedVerseObjects = null
+        const verseTextChangedFromLastEdit = _newVerseText !== newVerseText
         const verseTextChanged = _newVerseText !== initialVerseText
         const newState = {
           editing: editing_,
@@ -513,13 +514,20 @@ export function useScriptureAlignmentEdit({
           verseTextChanged,
         }
 
-        if (!editing_ && verseTextChanged) { // if done editing and verse has changed, update the verse objects
-          // do migration of alignments to match latest original language
-          _updatedVerseObjects = migrateAlignments('setEditing()', updatedVerseObjects || currentVerseObjects)
-          // apply alignments from updated verseObjects to edited verse text
-          const { targetVerseObjects } = AlignmentHelpers.updateAlignmentsToTargetVerse(_updatedVerseObjects, _newVerseText)
-          _updatedVerseObjects = targetVerseObjects // update verseObjects to match current text
-          newState['updatedVerseObjects'] = _updatedVerseObjects
+        if (!editing_) { // if done editing and verse has changed, update the verse objects
+          if (verseTextChanged) { // if verse has changed from initial, update the verse objects
+            // do migration of alignments to match latest original language
+            _updatedVerseObjects = migrateAlignments('setEditing()', updatedVerseObjects || currentVerseObjects)
+            // apply alignments from updated verseObjects to edited verse text
+            const { targetVerseObjects } = AlignmentHelpers.updateAlignmentsToTargetVerse(_updatedVerseObjects, _newVerseText)
+            _updatedVerseObjects = targetVerseObjects // update verseObjects to match current text
+            newState['updatedVerseObjects'] = _updatedVerseObjects
+          } else if (verseTextChangedFromLastEdit) { // if verse changed from last time (went back to initial text), update the verse objects without migration
+            _updatedVerseObjects = updatedVerseObjects || currentVerseObjects
+            const { targetVerseObjects } = AlignmentHelpers.updateAlignmentsToTargetVerse(_updatedVerseObjects, _newVerseText)
+            _updatedVerseObjects = targetVerseObjects // update verseObjects to match current text
+            newState['updatedVerseObjects'] = _updatedVerseObjects
+          }
         }
 
         setState(newState)

--- a/yarn.lock
+++ b/yarn.lock
@@ -11910,10 +11910,10 @@ schema-utils@^3.0.0:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-scripture-resources-rcl@5.5.8:
-  version "5.5.8"
-  resolved "https://registry.yarnpkg.com/scripture-resources-rcl/-/scripture-resources-rcl-5.5.8.tgz#edca70cb18f8c02b1c9c195a43bb3e8044fa6a09"
-  integrity sha512-RC82kGdA8jaclxwABRXFJkw9Bh5Ig3juBJY+vig8qsVLEU6EiHSuB5htz8BxkNPVUw7y5wpxxJeCb0rEATmEJA==
+scripture-resources-rcl@^5.5.8:
+  version "5.5.9"
+  resolved "https://registry.yarnpkg.com/scripture-resources-rcl/-/scripture-resources-rcl-5.5.9.tgz#a82ec412b92e4b64b3e75e220db8577410badb83"
+  integrity sha512-riVKnzK3xyQO+YSXIz8N4am2cz6WTcNPjoZNF36bo2mFlDPSzCE2nbH48pvMiy0cxwvzfmScuvJcwbbqR5Na9w==
   dependencies:
     bible-reference-range "^1.1.0"
     deep-freeze "^0.0.1"


### PR DESCRIPTION
## Describe what your pull request addresses

- [ ] remove processing of alignment status on each change of text edit (which caused state changes, processing and re-renders on each character change). Now processing is only done when done editing.
- [ ] display spinner while processing final text on blur
- [ ] disable save and align buttons on scripture card while editing so incomplete data is not aligned or saved.

## Test Instructions

- [ ] test with https://deploy-preview-618--gateway-edit.netlify.app/
- [ ] edit a verse and paste in a large text block
- [ ] then type some more characters and should not see any delays for characters typed in.
- [ ] when you are editing, you should see the save and align buttons grayed out.  If you try clicking on them, you should only see the processing spinner as edit window loses context.  You should not see saving of verse changes or alignment dialog pop up - just the processing spinner.
- [ ] when you leave text edit window, should see spinner when processing new edit text
- [ ] after processing finished, save and alignment button should be re-enabled.
