### PR TITLE
Increases the line height of Hebrew text

### DIFF
--- a/src/components/ScriptureCard/ScriptureCard.tsx
+++ b/src/components/ScriptureCard/ScriptureCard.tsx
@@ -492,6 +492,7 @@ export default function ScriptureCard({
   const contentStyle = React.useMemo(() => ({
     fontFamily: 'Noto Sans',
     fontSize: `${scaledFontSize}%`,
+    ...(isHebrew ? {lineHeight: '2.0em'} : {})
   }), [scaledFontSize])
 
   const scriptureLabel = <Title>{scriptureTitle}</Title>


### PR DESCRIPTION
## Describe what your pull request addresses

Makes only the Hebrew text have a line height of 2.0em when in a scripture card

## Test Instructions

- [ ] ensure Hebrew text in the scripture cards has a line height of 2.0em using the inspector in the web developer tools
